### PR TITLE
Several Improvements

### DIFF
--- a/QuickFont/Configuration/QFontBuilderConfiguration.cs
+++ b/QuickFont/Configuration/QFontBuilderConfiguration.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace QuickFont
 {
@@ -263,6 +265,12 @@ namespace QuickFont
                     }
                 }
             }
+            var hset = new HashSet<char>();
+            foreach (var c in result)
+            {
+                hset.Add(c);
+            }
+            result = new string(hset.ToArray());
             return result;
         }
 

--- a/QuickFont/QFontDrawing.cs
+++ b/QuickFont/QFontDrawing.cs
@@ -263,10 +263,10 @@ void main(void)
         {
             var dp = new QFontDrawingPimitive(font, opt);
             DrawingPimitiveses.Add(dp);
-            return dp.Print(text, position);
+            return dp.Print(text, position, opt.ClippingRectangle);
         }
 
-        public SizeF Print(QFont font, ProcessedText processedText, Vector3 position, Color? colour = null)
+        public SizeF Print(QFont font, ProcessedText processedText, Vector3 position, Color? colour = null, Rectangle clippingRectangle = default(Rectangle))
         {
             var dp = new QFontDrawingPimitive(font);
             DrawingPimitiveses.Add(dp);
@@ -280,30 +280,30 @@ void main(void)
         {
             var dp = new QFontDrawingPimitive(font, opt);
             DrawingPimitiveses.Add(dp);
-            return dp.Print(text, position, alignment);
+            return dp.Print(text, position, alignment, opt.ClippingRectangle);
         }
 
-        public SizeF Print(QFont font, string text, Vector3 position, QFontAlignment alignment, Color? color = null)
+        public SizeF Print(QFont font, string text, Vector3 position, QFontAlignment alignment, Color? color = null, Rectangle clippingRectangle = default(Rectangle))
         {
             var dp = new QFontDrawingPimitive(font);
             DrawingPimitiveses.Add(dp);
             if( color.HasValue )
-                return dp.Print(text, position, alignment, color.Value);
-            return dp.Print(text, position, alignment);
+                return dp.Print(text, position, alignment, color.Value, clippingRectangle);
+            return dp.Print(text, position, alignment, clippingRectangle);
         }
 
-        public SizeF Print(QFont font, string text, Vector3 position, SizeF maxSize, QFontAlignment alignment)
+        public SizeF Print(QFont font, string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, Rectangle clippingRectangle = default(Rectangle))
         {
             var dp = new QFontDrawingPimitive(font);
             DrawingPimitiveses.Add(dp);
-            return dp.Print(text, position, maxSize, alignment);
+            return dp.Print(text, position, maxSize, alignment, clippingRectangle);
         }
 
-        public SizeF Print(QFont font, string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, QFontRenderOptions opts )
+        public SizeF Print(QFont font, string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, QFontRenderOptions opt )
         {
-            var dp = new QFontDrawingPimitive(font, opts);
+            var dp = new QFontDrawingPimitive(font, opt);
             DrawingPimitiveses.Add(dp);
-            return dp.Print(text, position, maxSize, alignment);
+            return dp.Print(text, position, maxSize, alignment, opt.ClippingRectangle);
         }
 
         #region IDisposable impl

--- a/QuickFont/QFontDrawingPimitive.cs
+++ b/QuickFont/QFontDrawingPimitive.cs
@@ -70,21 +70,96 @@ namespace QuickFont
 
         internal IList<QVertex> ShadowVertexRepr { get { return _shadowVertexRepr; } }
 
-        private void RenderDropShadow(float x, float y, char c, QFontGlyph nonShadowGlyph, QFont shadowFont)
+        private void RenderDropShadow(float x, float y, char c, QFontGlyph nonShadowGlyph, QFont shadowFont, ref Rectangle clippingRectangle)
         {
             //note can cast drop shadow offset to int, but then you can't move the shadow smoothly...
             if (shadowFont != null && this.Options.DropShadowActive)
             {
-                this.RenderGlyphFinal(
-                    x + (_font.FontData.meanGlyphWidth * this.Options.DropShadowOffset.X + nonShadowGlyph.rect.Width * 0.5f),
-                    y +
-                    (_font.FontData.meanGlyphWidth * this.Options.DropShadowOffset.Y + nonShadowGlyph.rect.Height * 0.5f +
-                     nonShadowGlyph.yOffset), c, shadowFont, this.ShadowVertexRepr);
+                float xOffset = (_font.FontData.meanGlyphWidth*this.Options.DropShadowOffset.X + nonShadowGlyph.rect.Width*0.5f);
+                float yOffset = (_font.FontData.meanGlyphWidth*this.Options.DropShadowOffset.Y + nonShadowGlyph.rect.Height*0.5f + nonShadowGlyph.yOffset);
+                this.RenderGlyph(x + xOffset, y + yOffset, c, shadowFont, this.ShadowVertexRepr, clippingRectangle);
             }
         }
+        
+        private bool ScissorsTest(ref float x, ref float y, ref float width, ref float height, ref float u1, ref float v1, ref float u2, ref float v2, Rectangle clipRectangle)
+        {
+            if (y > clipRectangle.Y + clipRectangle.Height)
+            {
+                float oldHeight = height;
+                float delta = y - (clipRectangle.Y + clipRectangle.Height);
+                y = clipRectangle.Y + clipRectangle.Height;
+                height -= delta;
 
+                if (height <= 0)
+                {
+                    return true;
+                }
 
-        private void RenderGlyphFinal(float x, float y, char c, QFont font, IList<QVertex> store)
+                float dv = (float)delta / (float)oldHeight;
+
+                v1 += dv * (v2 - v1);
+            }
+
+            if ((y - height) < (clipRectangle.Y))
+            {
+                float oldHeight = height;
+                float delta = (y - height) - clipRectangle.Y;
+
+                height -= delta;
+
+                if (height <= 0)
+                {
+                    return true;
+                }
+
+                float dv = (float) delta/(float) oldHeight;
+
+                v2 -= dv*(v2 - v1);
+            }
+
+            if (x < clipRectangle.X)
+            {
+                float oldWidth = width;
+                float delta = clipRectangle.X - x;
+                x = clipRectangle.X;
+                width -= delta;
+
+                if (width <= 0)
+                {
+                    return true;
+                }
+
+                float du = (float)delta / (float)oldWidth;
+
+                u1 += du * (u2 - u1);
+            }
+
+            if ((x + width) > (clipRectangle.X + clipRectangle.Width))
+            {
+                float oldWidth = width;
+                float delta = (x + width) - (clipRectangle.X + clipRectangle.Width);
+
+                width -= delta;
+
+                if (width <= 0)
+                {
+                    return true;
+                }
+
+                float du = (float)delta / (float)oldWidth;
+
+                u2 -= du * (u2 - u1);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Renders the glyph at the position given.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <param name="y">The y.</param>
+        /// <param name="c">The character to print.</param>
+        internal void RenderGlyph(float x, float y, char c, QFont font, IList<QVertex> store, Rectangle clippingRectangle)
         {
             QFontGlyph glyph = font.FontData.CharSetMapping[c];
 
@@ -98,7 +173,7 @@ namespace QuickFont
             }
             else
             {
-                RenderDropShadow(x, y, c, glyph, font.FontData.dropShadowFont);
+                RenderDropShadow(x, y, c, glyph, font.FontData.dropShadowFont, ref clippingRectangle);
             }
 
             y = -y;
@@ -110,15 +185,22 @@ namespace QuickFont
             float tx2 = (float)(glyph.rect.X + glyph.rect.Width) / sheet.Width;
             float ty2 = (float)(glyph.rect.Y + glyph.rect.Height) / sheet.Height;
 
+            float vx = x + PrintOffset.X;
+            float vy = y - glyph.yOffset + PrintOffset.Y;
+            float vwidth = glyph.rect.Width;
+            float vheight = glyph.rect.Height;
+
+            if (clippingRectangle != default(Rectangle) && ScissorsTest(ref vx, ref vy, ref vwidth, ref vheight, ref tx1, ref ty1, ref tx2, ref ty2, clippingRectangle)) return;
+
             var tv1 = new Vector2(tx1, ty1);
             var tv2 = new Vector2(tx1, ty2);
             var tv3 = new Vector2(tx2, ty2);
             var tv4 = new Vector2(tx2, ty1);
 
-            Vector3 v1 = PrintOffset + new Vector3(x, y - glyph.yOffset, 0);
-            Vector3 v2 = PrintOffset + new Vector3(x, y - glyph.yOffset - glyph.rect.Height, 0);
-            Vector3 v3 = PrintOffset + new Vector3(x + glyph.rect.Width, y - glyph.yOffset - glyph.rect.Height, 0);
-            Vector3 v4 = PrintOffset + new Vector3(x + glyph.rect.Width, y - glyph.yOffset, 0);
+            Vector3 v1 = new Vector3(vx, vy, PrintOffset.Z);
+            Vector3 v2 = new Vector3(vx, vy - vheight, PrintOffset.Z);
+            Vector3 v3 = new Vector3(vx + vwidth, vy - vheight, PrintOffset.Z);
+            Vector3 v4 = new Vector3(vx + vwidth, vy, PrintOffset.Z);
 
             Color color;
             if (font.FontData.isDropShadow)
@@ -137,18 +219,6 @@ namespace QuickFont
             store.Add(new QVertex() { Position = v4, TextureCoord = tv4, VertexColor = colour });
         }
 
-        /// <summary>
-        /// Renders the glyph at the position given. Adds a drop shadow if configured.
-        /// </summary>
-        /// <param name="x">The x.</param>
-        /// <param name="y">The y.</param>
-        /// <param name="c">The character to print.</param>
-        public void RenderGlyph(float x, float y, char c)
-        {
-            //if (_font.FontData.dropShadowFont != null)
-            //    RenderGlyphFinal(x, y, c, _font.FontData.dropShadowFont, ShadowVertexRepr);
-            RenderGlyphFinal(x, y, c, _font, CurrentVertexRepr);
-        }
 
         private float MeasureNextlineLength(string text)
         {
@@ -254,42 +324,42 @@ namespace QuickFont
             return new Vector3(LockToPixel(TransformPositionToViewport(input.Xy))) {Z = input.Z};
         }
 
-        public SizeF Print(string text, Vector3 position, SizeF maxSize, QFontAlignment alignment)
-        {
-            ProcessedText processedText = ProcessText(_font, Options, text, maxSize, alignment);
-            return Print(processedText, TransformToViewport(position));
-        }
-
-        public SizeF Print(string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, Color colour)
-        {
-            ProcessedText processedText = ProcessText(_font, Options, text, maxSize, alignment);
-            return Print(processedText, TransformToViewport(position), colour);
-        }
-
-        public SizeF Print(ProcessedText processedText, Vector3 position)
+        public SizeF Print(string text, Vector3 position, QFontAlignment alignment, Rectangle clippingRectangle = default(Rectangle))
         {
             PrintOffset = TransformToViewport(position);
-            return PrintOrMeasure(processedText, false);
+            return PrintOrMeasure(text, alignment, false, clippingRectangle);
         }
 
-        public SizeF Print(ProcessedText processedText, Vector3 position, Color colour)
-        {
-            this.Options.Colour = colour;
-            PrintOffset = TransformToViewport(position);
-            return PrintOrMeasure(processedText, false);
-        }
-
-        public SizeF Print(string text, Vector3 position, QFontAlignment alignment)
-        {
-            PrintOffset = TransformToViewport(position);
-            return PrintOrMeasure(text, alignment, false);
-        }
-
-        public SizeF Print(string text, Vector3 position, QFontAlignment alignment, Color color)
+        public SizeF Print(string text, Vector3 position, QFontAlignment alignment, Color color, Rectangle clippingRectangle = default(Rectangle))
         {
             this.Options.Colour = color;
             PrintOffset = TransformToViewport(position);
-            return PrintOrMeasure(text, alignment, false);
+            return PrintOrMeasure(text, alignment, false, clippingRectangle);
+        }
+
+        public SizeF Print(string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, Rectangle clippingRectangle = default(Rectangle))
+        {
+            ProcessedText processedText = ProcessText(_font, Options, text, maxSize, alignment);
+            return Print(processedText, TransformToViewport(position), clippingRectangle);
+        }
+
+        public SizeF Print(string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, Color colour, Rectangle clippingRectangle = default(Rectangle))
+        {
+            ProcessedText processedText = ProcessText(_font, Options, text, maxSize, alignment);
+            return Print(processedText, TransformToViewport(position), colour, clippingRectangle);
+        }
+
+        public SizeF Print(ProcessedText processedText, Vector3 position, Rectangle clippingRectangle = default(Rectangle))
+        {
+            PrintOffset = TransformToViewport(position);
+            return PrintOrMeasure(processedText, false, clippingRectangle);
+        }
+
+        public SizeF Print(ProcessedText processedText, Vector3 position, Color colour, Rectangle clippingRectangle = default(Rectangle))
+        {
+            this.Options.Colour = colour;
+            PrintOffset = TransformToViewport(position);
+            return PrintOrMeasure(processedText, false, clippingRectangle);
         }
 
         public SizeF Measure(string text, QFontAlignment alignment = QFontAlignment.Left)
@@ -325,7 +395,7 @@ namespace QuickFont
             return TransformMeasureFromViewport(PrintOrMeasure(processedText, true));
         }
 
-        private SizeF PrintOrMeasure(string text, QFontAlignment alignment, bool measureOnly)
+        private SizeF PrintOrMeasure(string text, QFontAlignment alignment, bool measureOnly, Rectangle clippingRectangle = default(Rectangle))
         {
             float maxWidth = 0f;
             float xOffset = 0f;
@@ -366,7 +436,7 @@ namespace QuickFont
                     if (c != ' ' && _font.FontData.CharSetMapping.ContainsKey(c))
                     {
                         if (!measureOnly)
-                            RenderGlyph(xOffset, yOffset, c);
+                            RenderGlyph(xOffset, yOffset, c, _font, CurrentVertexRepr, clippingRectangle);
                     }
 
                     if (IsMonospacingActive)
@@ -396,7 +466,7 @@ namespace QuickFont
             return LastSize;
         }
 
-        private SizeF PrintOrMeasure(ProcessedText processedText, bool measureOnly)
+        private SizeF PrintOrMeasure(ProcessedText processedText, bool measureOnly, Rectangle clippingRectangle = default(Rectangle))
         {
             // init values we'll return
             float maxMeasuredWidth = 0f;
@@ -453,7 +523,7 @@ namespace QuickFont
                         atLeastOneNodeCosumedOnLine = true;
 
                         if (!measureOnly)
-                            RenderWord(xOffset + length, yOffset, node);
+                            RenderWord(xOffset + length, yOffset, node, ref clippingRectangle);
                         length += node.ModifiedLength;
 
                         maxMeasuredWidth = Math.Max(length, maxMeasuredWidth);
@@ -495,7 +565,7 @@ namespace QuickFont
             return LastSize;
         }
 
-        private void RenderWord(float x, float y, TextNode node)
+        private void RenderWord(float x, float y, TextNode node, ref Rectangle clippingRectangle)
         {
             if (node.Type != TextNodeType.Word)
                 return;
@@ -521,7 +591,7 @@ namespace QuickFont
                 {
                     QFontGlyph glyph = _font.FontData.CharSetMapping[c];
 
-                    RenderGlyph(x, y, c);
+                    RenderGlyph(x, y, c, _font, CurrentVertexRepr, clippingRectangle);
 
 
                     if (IsMonospacingActive)

--- a/QuickFont/QFontDrawingPimitive.cs
+++ b/QuickFont/QFontDrawingPimitive.cs
@@ -61,6 +61,8 @@ namespace QuickFont
 
         public QFontRenderOptions Options { get; private set; }
 
+        public SizeF LastSize { get; private set; }
+
         internal IList<QVertex> CurrentVertexRepr
         {
             get { return _currentVertexRepr; }
@@ -390,7 +392,8 @@ namespace QuickFont
             if (minXPos != float.MaxValue)
                 maxWidth = maxXpos - minXPos;
 
-            return new SizeF(maxWidth, yOffset + LineSpacing);
+            LastSize = new SizeF(maxWidth, yOffset + LineSpacing);
+            return LastSize;
         }
 
         private SizeF PrintOrMeasure(ProcessedText processedText, bool measureOnly)
@@ -488,7 +491,8 @@ namespace QuickFont
                 }
             }
 
-            return new SizeF(maxMeasuredWidth, yOffset + LineSpacing - yPos);
+            LastSize = new SizeF(maxMeasuredWidth, yOffset + LineSpacing - yPos);
+            return LastSize;
         }
 
         private void RenderWord(float x, float y, TextNode node)
@@ -854,6 +858,5 @@ namespace QuickFont
 
             return processedText;
         }
-
     }
 }

--- a/QuickFont/QFontRenderOptions.cs
+++ b/QuickFont/QFontRenderOptions.cs
@@ -227,6 +227,8 @@ namespace QuickFont
         /// </summary>
         public float JustifyContractionPenalty = 2;
 
+        public Rectangle ClippingRectangle = default(Rectangle);
+
         #endregion
 
         public QFontRenderOptions CreateClone()
@@ -252,6 +254,7 @@ namespace QuickFont
             clone.JustifyCapExpand = JustifyCapExpand;
             clone.JustifyCapContract = JustifyCapContract;
             clone.JustifyContractionPenalty = JustifyContractionPenalty;
+            clone.ClippingRectangle = ClippingRectangle;
 
             return clone;
         }


### PR DESCRIPTION
The font building mechanism will now search for a font in the installed system font collection if it can't be found as a file.
The property LastSize is exposed in QFontDrawingPrimitive, which caches the last printed/measured string size.
Add a check to ensure that each character in the character set used by the builder is unique.
Added support for cpu scissor testing via clipping rectangles. This was needed to easily support GUI systems built using QuickFont, specifically Gwen.NET (see https://github.com/opcon/gwen-nolegacy-opentk-renderer/issues/1).