### PR TITLE
QuickFont 4.3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# top-most EditorConfig file
+root = true
+
+# Use Unix-style newlines, newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Source code file style
+[*.cs]
+indent_style = space
+indent_size = 4
+
+# yml and json matching
+[*.{json,yml}]
+indent_style = space
+indent_size = 2

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -73,6 +73,10 @@
     <None Include="Fonts\times.ttf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Content Include="..\packages\SharpFont.Dependencies.2.6\bin\msvc12\x64\freetype6.dll">
+      <Link>freetype6.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="woodenFont.qfont">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Example/Game.cs
+++ b/Example/Game.cs
@@ -234,8 +234,8 @@ namespace Example
 	        {
 		        ShadowConfig =
 		        {
-			        blurRadius = 2,
-			        blurPasses = 1,
+			        BlurRadius = 2,
+			        BlurPasses = 1,
 			        Type = ShadowType.Blurred
 		        },
 		        TextGenerationRenderHint = TextGenerationRenderHint.ClearTypeGridFit,

--- a/Example/Game.cs
+++ b/Example/Game.cs
@@ -49,7 +49,7 @@ namespace StarterKit
             "The difference to opcon/QuickFont therefore is a big Refactoring. The original (god like) QFont-class has been separated in 3 concerns: " +
             "Actual Font (save, create, hold texture) [QFont], Drawing-primitive (layout + vertex computations) [QFontDrawingPrimitive] "+
             "and a Drawing container (push stuff to OpenGL, draw) [QFontDrawing]. " +
-            "Unfortunately or naturally the API has changed remarkably so that old code is nop longer compatible. "+
+            "Unfortunately or naturally the API has changed remarkably so that old code is no longer compatible. "+
             "However the changes are not radical and can be adapted (some conceptual changes may surface) as you can see with thsi example. "+
             "This refactoring into three classes should make using QuickFont more flexible and more pleasing to use. " +
             "It lost of it's ease because you have to handle more classes. But your code will be more future proof and architected well.";
@@ -433,7 +433,7 @@ namespace StarterKit
                                         .Height;
 
                             yOffset += drawing.Print(mainText, modernQuickFontIntro, new Vector3(30, Height - yOffset, 0),
-                                                                 new SizeF(Width - 60f, -1), QFontAlignment.Justify, new Rectangle(60, Height-400, 200, 200)).Height;
+                                                                 new SizeF(Width - 60f, -1), QFontAlignment.Left).Height;
                             
                             PrintCode(modernIntroCode, ref yOffset);
                             break;

--- a/Example/Game.cs
+++ b/Example/Game.cs
@@ -3,35 +3,32 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq.Expressions;
+using System.Drawing;
+using System.Drawing.Text;
 using OpenTK;
 using OpenTK.Graphics;
+using OpenTK.Graphics.OpenGL4;
+using OpenTK.Input;
+using QuickFont;
+using QuickFont.Configuration;
 #if OPENGL_ES
 using OpenTK.Graphics.ES20;
 #else
-using OpenTK.Graphics.OpenGL4;
 #endif
-using OpenTK.Audio;
-using OpenTK.Audio.OpenAL;
-using OpenTK.Input;
-using QuickFont;
-using System.Drawing;
-using System.Drawing.Text;
-using QuickFont.Configuration;
 
-namespace StarterKit
+namespace Example
 {
     class Game : GameWindow
     {
-        QFont heading1;
-        QFont heading2;
-        QFont mainText;
-        QFont codeText;
-        QFont controlsText;
-        QFont monoSpaced;
+        QFont _heading1;
+        QFont _heading2;
+        QFont _mainText;
+        QFont _codeText;
+        QFont _controlsText;
+        QFont _monoSpaced;
 
-        private QFontDrawing drawing;
-        private QFontDrawing controlsDrawing;
+        private QFontDrawing _drawing;
+        private QFontDrawing _controlsDrawing;
 
         private Stopwatch _stopwatch;
         private ProcessedText _processedText;
@@ -43,7 +40,7 @@ namespace StarterKit
 
 #region string constants
 
-        private String modernQuickFontIntro =
+        private readonly string _modernQuickFontIntro =
             @"Welcome to ModernQuickFont. This is yet another fork of the original library QuickFont (which uses ordinary OpenGL). " +
             "This is actually a fork of opcon/QuickFont and thus (as the name implies) is a modern OpenGL implementation using VBOs and VAOs. " +
             "The difference to opcon/QuickFont therefore is a big Refactoring. The original (god like) QFont-class has been separated in 3 concerns: " +
@@ -53,155 +50,158 @@ namespace StarterKit
             "However the changes are not radical and can be adapted (some conceptual changes may surface) as you can see with thsi example. "+
             "This refactoring into three classes should make using QuickFont more flexible and more pleasing to use. " +
             "It lost of it's ease because you have to handle more classes. But your code will be more future proof and architected well.";
-        String modernIntroCode = @"myFont = new QFont(""Fonts/HappySans.ttf"", 72, new QFontBuilderConfiguration(true));"+ Environment.NewLine +
+
+	    readonly string _modernIntroCode = @"myFont = new QFont(""Fonts/HappySans.ttf"", 72, new QFontBuilderConfiguration(true));"+ Environment.NewLine +
             "drawing = new QFontDrawing();" + Environment.NewLine +
             @"drawing.Print(myFont, ""text"", pos, FontAlignment.Left, opts);" + Environment.NewLine +
             "for { drawing.Draw(); }";
 
-        String introduction = @"Welcome to the QuickFont tutorial. All text in this tutorial (including headings!) is drawn with QuickFont, so it is also intended to showcase the library. :) If you want to get started immediately, you can skip the rest of this introduction by pressing [Right]. You can also press [Left] to go back to previous pages at any point" + Environment.NewLine + Environment.NewLine +
+	    readonly string _introduction = @"Welcome to the QuickFont tutorial. All text in this tutorial (including headings!) is drawn with QuickFont, so it is also intended to showcase the library. :) If you want to get started immediately, you can skip the rest of this introduction by pressing [Right]. You can also press [Left] to go back to previous pages at any point" + Environment.NewLine + Environment.NewLine +
             "Why QuickFont? QuickFont is intended as a replacement (and improvement upon) OpenTK's TextPrinter library. My primary motivation for writing it was for practical reasons: I'm using OpenTK to write a game, and currently the most annoying bugs are all being caused by TextPrinter: it is slow, it is buggy, and no one wants to maintain it." + Environment.NewLine + Environment.NewLine +
             "I did consider simply fixing it, but then decided that it would be easier and more fun to write my own library from scratch. That is exactly what I've done." + Environment.NewLine + Environment.NewLine +
             "In fact it's turned out to be well worth it. It has only taken me a few days to write the library, and already it has quite a few really cool features which I will be using in my game.";
 
-        String usingQuickFontIsSuperEasy = @"Using QuickFont is super easy. To load a font: ";
-        String loadingAFont1 = "myFont = new QFont(\"HappySans.ttf\", 16);";
-        String andPrintWithIt = @"...and to print with it: ";
-        String printWithFont1 = "mainText.Begin();" + Environment.NewLine + "myFont.Print(\"Hello World!\")" + Environment.NewLine + "mainText.End();";
-        String itIsAlsoEasyToMeasure = "It is also very easy to measure text: ";
-        String measureText1 = "var bounds = myFont.Measure(\"Hello World\"); ";
+	    readonly string _usingQuickFontIsSuperEasy = @"Using QuickFont is super easy. To load a font: ";
+	    readonly string _loadingAFont1 = "myFont = new QFont(\"HappySans.ttf\", 16);";
+	    readonly string _andPrintWithIt = @"...and to print with it: ";
+	    readonly string _printWithFont1 = "mainText.Begin();" + Environment.NewLine + "myFont.Print(\"Hello World!\")" + Environment.NewLine + "mainText.End();";
+	    readonly string _itIsAlsoEasyToMeasure = "It is also very easy to measure text: ";
+	    readonly string _measureText1 = "var bounds = myFont.Measure(\"Hello World\"); ";
 
-        String oneOfTheFirstGotchas = "One of the first \"gotchas\" that I experienced with the old TextPrinter was having to manage a private font collection. Unlike TextPrinter, QuickFont does not need the private font collection (or Font object for that matter) to exist after construction. QuickFont works out everything it needs at load time, hence you can just pass it a file name, it will load the pfc internally and then chuck it away immediately. If you still prefer to manage a font collection yourself, and you simply want to create a QuickFont from a font object, that's fine: QuickFont has a constructor for this:  ";
-        String loadingAFont2 = "myFont = new QFont(fontObject);";
+	    private readonly string oneOfTheFirstGotchas = "One of the first \"gotchas\" that I experienced with the old TextPrinter was having to manage a private font collection. Unlike TextPrinter, QuickFont does not need the private font collection (or Font object for that matter) to exist after construction. QuickFont works out everything it needs at load time, hence you can just pass it a file name, it will load the pfc internally and then chuck it away immediately. If you still prefer to manage a font collection yourself, and you simply want to create a QuickFont from a font object, that's fine: QuickFont has a constructor for this:  ";
+	    readonly string _loadingAFont2 = "myFont = new QFont(fontObject);";
 
-        String whenPrintingText = "When printing text, you can specify" + Environment.NewLine +
+	    readonly string _whenPrintingText = "When printing text, you can specify" + Environment.NewLine +
                                   "an alignment. Unbounded text can" + Environment.NewLine + 
                                   "be left-aligned, right-aligned " + Environment.NewLine +
                                   "or centered. You specify the " + Environment.NewLine + 
                                   "alignment as follows: ";
 
-        String printWithFont2 = "myFont.Print(\"Hello World!\",QFontAlignment.Right)";
+	    readonly string _printWithFont2 = "myFont.Print(\"Hello World!\",QFontAlignment.Right)";
 
-        String righAlignedText = "Right-aligned text will appear" + Environment.NewLine +
+	    readonly string _righAlignedText = "Right-aligned text will appear" + Environment.NewLine +
                                  "to the left of the original" + Environment.NewLine +
                                  "position, given by this red line.";
 
-        String centredTextAsYou = "Centred text, as you would expect, is centred" + Environment.NewLine +
+	    readonly string _centredTextAsYou = "Centred text, as you would expect, is centred" + Environment.NewLine +
                                   "around the current position. The default alignment" + Environment.NewLine +
                                   "is Left. As you can see, you can include " + Environment.NewLine +
                                   "line-breaks in unbounded text.";
 
-        String ofCourseItsNot = "Of course, it's not much fun having to insert your own line-breaks. A much better option is to simply specify the bounds of your text, and then let QuickFont decide where the line-breaks should go for you. You do this by specifying maxWidth. " + Environment.NewLine + Environment.NewLine +
+	    readonly string _ofCourseItsNot = "Of course, it's not much fun having to insert your own line-breaks. A much better option is to simply specify the bounds of your text, and then let QuickFont decide where the line-breaks should go for you. You do this by specifying maxWidth. " + Environment.NewLine + Environment.NewLine +
                                "You can still specify line-breaks for new paragraphs. For example, this is all written using a single print. QuickFont is also clever enough to spot where it might have accidentally inserted a line-break just before you have explicitly included one in the text. In this case, it will make sure that it does not insert a redundant line-break. :)" + Environment.NewLine + Environment.NewLine +
                                "Another really cool feature of QuickFont, as you may have guessed already, is that it supports justified bounded text. It was quite tricky to get it all working pixel-perfectly, but as you can see, the results are pretty good. The precise justification settings are configurable in myFont.Options." + Environment.NewLine + Environment.NewLine +
                                "You can press the [Up] and [Down] arrow keys to change the alignment on this block of bounded text. You can also press the [Enter] key to test some serious bounding! Note that the bound height is always ignored.";
 
-        String anotherCoolFeature = "QuickFont works by using the System.Drawing to render to a bitmap, and then measuring and targeting each glyph before packing them into another bitmap which is then turned into an OpenGL texture. So essentially all fonts are \"texture\" fonts. However, QuickFont also allows you to get at the bitmaps before they are turned into OpenGL textures, save them to png file(s), modify them and then load (and retarget/remeasure) them again as QFonts. Sound complicated? - Don't worry, it's really easy. :)" + Environment.NewLine + Environment.NewLine +
+	    readonly string _anotherCoolFeature = "QuickFont works by using the System.Drawing to render to a bitmap, and then measuring and targeting each glyph before packing them into another bitmap which is then turned into an OpenGL texture. So essentially all fonts are \"texture\" fonts. However, QuickFont also allows you to get at the bitmaps before they are turned into OpenGL textures, save them to png file(s), modify them and then load (and retarget/remeasure) them again as QFonts. Sound complicated? - Don't worry, it's really easy. :)" + Environment.NewLine + Environment.NewLine +
                                     "Firstly, you need to create your new silhouette files from an existing font. You only want to call this code once, as calling it again will overwrite your modified .png, so take care. :) ";
 
-        String textureFontCode1 = "QFont.CreateTextureFontFiles(\"HappySans.ttf\",16,\"myTextureFont\");";
+	    readonly string _textureFontCode1 = "QFont.CreateTextureFontFiles(\"HappySans.ttf\",16,\"myTextureFont\");";
 
-        String thisWillHaveCreated = "This will have created two files: \"myTextureFont.qfont\" and \"myTextureFont.png\" (or possibly multiple png files if your font is very large - I will explain how to configure this later). The next step is to actually texture your font. The png file(s) contain packed font silhouettes, perfect for layer effects in programs such as photoshop or GIMP. I suggest locking the alpha channel first, because QuickFont will complain if you merge two glyphs. You can enlarge glyphs at this stage, and QuickFont will automatically retarget each glyph when you next load the texture; however, it will fail if glyphs are merged...    ";
+	    readonly string _thisWillHaveCreated = "This will have created two files: \"myTextureFont.qfont\" and \"myTextureFont.png\" (or possibly multiple png files if your font is very large - I will explain how to configure this later). The next step is to actually texture your font. The png file(s) contain packed font silhouettes, perfect for layer effects in programs such as photoshop or GIMP. I suggest locking the alpha channel first, because QuickFont will complain if you merge two glyphs. You can enlarge glyphs at this stage, and QuickFont will automatically retarget each glyph when you next load the texture; however, it will fail if glyphs are merged...    ";
 
-        String ifYouDoIntend = "...if you do intend to increase the size of the glyphs, then you can configure the silhouette texture to be generated with larger glyph margins to avoid glyphs merging. Here, I've also configured the texture sheet size a bit larger because the font is large and I want it all on one sheet for convenience: ";
+	    readonly string _ifYouDoIntend = "...if you do intend to increase the size of the glyphs, then you can configure the silhouette texture to be generated with larger glyph margins to avoid glyphs merging. Here, I've also configured the texture sheet size a bit larger because the font is large and I want it all on one sheet for convenience: ";
 
-        String textureFontCode2 = "QFontBuilderConfiguration config = new QFontBuilderConfiguration();" + Environment.NewLine +
+	    readonly string _textureFontCode2 = "QFontBuilderConfiguration config = new QFontBuilderConfiguration();" + Environment.NewLine +
             "config.GlyphMargin = 6;" + Environment.NewLine +
             "config.PageWidth = 1024;" + Environment.NewLine +
             "config.PageHeight = 1024;" + Environment.NewLine +
             "QFont.CreateTextureFontFiles(\"HappySans.ttf\",48,config,\"myTextureFont\");";
 
-        String actuallyTexturing = "Actually texturing the glyphs is really going to come down to how skilled you are in photoshop, and how good the original font was that you chose as a silhouette. To give you an idea: this very cool looking font I'm using for headings only took me 3 minutes to texture in photoshop because I did it with layer affects that did all glyphs at once. :)" + Environment.NewLine + Environment.NewLine +
+	    readonly string _actuallyTexturing = "Actually texturing the glyphs is really going to come down to how skilled you are in photoshop, and how good the original font was that you chose as a silhouette. To give you an idea: this very cool looking font I'm using for headings only took me 3 minutes to texture in photoshop because I did it with layer affects that did all glyphs at once. :)" + Environment.NewLine + Environment.NewLine +
             "Anyway, once you've finished texturing your font, save the png file. Now you can load the font and write with it just like any other font!";
 
-        String textureFontCode3 = "myTexureFont = QFont.FromQFontFile(\"myTextureFont.qfont\");";
+	    readonly string _textureFontCode3 = "myTexureFont = QFont.FromQFontFile(\"myTextureFont.qfont\");";
 
-        String asIhaveleant = "As I have learnt, trying to create drop-shadows as part of the glyphs themselves gives very poor results because the glyphs become larger than usual and the font looks poor when printed. To do drop-shadows properly, they need to be rendered separately underneath each glyph. This is what QuickFont does. In fact it does a lot more: it will generate the drop-shadow textures for you. It's super-easy to create a font with a drop-shadow: ";
-        String dropShadowCode1 = "myFont = new QFont(\"HappySans.ttf\", 16, new QFontBuilderConfiguration(true));";
-        String thisWorksFine = "This works fine for texture fonts too: ";
-        String dropShadowCode2 = "myTexureFont = QFont.FromQFontFile(\"myTextureFont.qfont\", new QFontLoaderConfiguration(true));";
-        String onceAFont = "Once a font has been loaded with a drop-shadow, it will automatically be rendered with a shadow. However, you can turn this off or customise the drop-shadow in myFont.options when rendering (I am rotating the drop shadow here, which looks kind of cool but is now giving me a headache xD). I've turned drop-shadows on for this font on this page; however, they are very subtle because the font is so tiny. If you want the shadow to be more visible for tiny fonts like this, you could modify the DropShadowConfiguration object passed into the font constructor to blur the shadow less severely during creation. ";
+	    readonly string _asIhaveleant = "As I have learnt, trying to create drop-shadows as part of the glyphs themselves gives very poor results because the glyphs become larger than usual and the font looks poor when printed. To do drop-shadows properly, they need to be rendered separately underneath each glyph. This is what QuickFont does. In fact it does a lot more: it will generate the drop-shadow textures for you. It's super-easy to create a font with a drop-shadow: ";
+	    readonly string _dropShadowCode1 = "myFont = new QFont(\"HappySans.ttf\", 16, new QFontBuilderConfiguration(true));";
+	    readonly string _thisWorksFine = "This works fine for texture fonts too: ";
+	    readonly string _dropShadowCode2 = "myTexureFont = QFont.FromQFontFile(\"myTextureFont.qfont\", new QFontLoaderConfiguration(true));";
+	    readonly string _onceAFont = "Once a font has been loaded with a drop-shadow, it will automatically be rendered with a shadow. However, you can turn this off or customise the drop-shadow in myFont.options when rendering (I am rotating the drop shadow here, which looks kind of cool but is now giving me a headache xD). I've turned drop-shadows on for this font on this page; however, they are very subtle because the font is so tiny. If you want the shadow to be more visible for tiny fonts like this, you could modify the DropShadowConfiguration object passed into the font constructor to blur the shadow less severely during creation. ";
 
-        String thereAreActually = "There are actually a lot more interesting config values and neat things that QuickFont does. Now that I look back at it, it's a bit crazy that I got this all done in a few days, but this tutorial is getting a bit tedious to write and I'm dying to get on with making my game, so I'm going to leave it at this. " + Environment.NewLine + Environment.NewLine +
+	    readonly string _thereAreActually = "There are actually a lot more interesting config values and neat things that QuickFont does. Now that I look back at it, it's a bit crazy that I got this all done in a few days, but this tutorial is getting a bit tedious to write and I'm dying to get on with making my game, so I'm going to leave it at this. " + Environment.NewLine + Environment.NewLine +
             "I suppose I should also mention that there are almost certainly going to be a few bugs. Let me know if you find any and I will get them fixed asap. :) " + Environment.NewLine + Environment.NewLine +
             "I should probably also say something about the code: it's not unit tested and it probably would need a good few hours of refactoring before it would be clean enough to be respectable. I will do this at some point. Also, feel free to berate me if I'm severely breaking any conventions. I'm a programmer by profession and really should know better. ;)" + Environment.NewLine + Environment.NewLine +
             "With regard to features: I'm probably not going to add many more to this library. It really is intended for rendering cool-looking text quickly for things like games. If you want highly formatted text, for example, then it probably isn't the right tool. I hope you find it useful; I know I already do! :P" + Environment.NewLine + Environment.NewLine +
             "A tiny disclaimer: all of QuickFont is written from scratch apart from ~100 lines I stole from TextPrinter for setting the correct perspective. Obviously the example itself is just a hacked around version of the original example that comes with OpenTK.";
 
-        String hereIsSomeMono = "Here is some mononspaced text.  Monospaced fonts will automatically be rendered in monospace mode; however, you can render monospaced fonts ordinarily " +
+	    readonly string _hereIsSomeMono = "Here is some mononspaced text.  Monospaced fonts will automatically be rendered in monospace mode; however, you can render monospaced fonts ordinarily " +
                                 "or ordinary fonts in monospace mode using the render option:";
-        String monoCode1 = " myFont.Options.Monospacing = QFontMonospacing.Yes; ";
-        String theDefaultMono = "The default value for this is QFontMonospacing.Natural which simply means that if the underlying font was monospaced, then use monospacing. ";
+
+	    readonly string _monoCode1 = " myFont.Options.Monospacing = QFontMonospacing.Yes; ";
+	    readonly string _theDefaultMono = "The default value for this is QFontMonospacing.Natural which simply means that if the underlying font was monospaced, then use monospacing. ";
 
 
-        String mono =           " **   **   **   *  *   **  " + Environment.NewLine +                  
+	    private readonly string _mono =           " **   **   **   *  *   **  " + Environment.NewLine +                  
                                 " * * * *  *  *  ** *  *  * " + Environment.NewLine +                
                                 " *  *  *  *  *  * **  *  * " + Environment.NewLine +             
                                 " *     *   **   *  *   **  ";
 
-        private string preProcessed = "Text can be preprocessed which improves rendering time. This text is preprocessed.";
-        private string nonPreProcessed = "Text can be preprocessed which improves rendering time. This text is not preprocessed.";
+        private readonly string _preProcessed = "Text can be preprocessed which improves rendering time. This text is preprocessed.";
+        private readonly string _nonPreProcessed = "Text can be preprocessed which improves rendering time. This text is not preprocessed.";
 #endregion
 
-        int currentDemoPage = 0;
-        int lastPage = 11;
-        private int frameCount = 0;
+        int _currentDemoPage;
+	    readonly int _lastPage = 11;
+	    private int _frameCount;
 
         private string _benchResult="";
 
-        QFontAlignment cycleAlignment = QFontAlignment.Left;
+        QFontAlignment _cycleAlignment = QFontAlignment.Left;
 
         /// <summary>Creates a 800x600 window with the specified title.</summary>
         public Game()
             : base(800, 600, GraphicsMode.Default, "QuickFont Example")
         {
             VSync = VSyncMode.Off;
-            this.WindowBorder = WindowBorder.Fixed;
+            WindowBorder = WindowBorder.Fixed;
 
             Debug.WriteLine(GL.GetString(StringName.Version));
         }
 
-        private void KeyDown(object sender, KeyboardKeyEventArgs keyEventArgs)
+
+	    protected override void OnKeyDown(KeyboardKeyEventArgs keyboardKeyEventArgs)
         {
-            int texmax = GL.GetInteger(GetPName.MaxTextureSize);
-            switch (keyEventArgs.Key)
+            GL.GetInteger(GetPName.MaxTextureSize);
+            switch (keyboardKeyEventArgs.Key)
             {
                 case Key.Space:
                 case Key.Right:
-                    currentDemoPage++;
+                    _currentDemoPage++;
                     break;
 
                 case Key.BackSpace:
                 case Key.Left:
-                    currentDemoPage--;
+                    _currentDemoPage--;
                     break;
 
                 case Key.Enter:
                 {
-                    if (currentDemoPage == 4)
-                        boundsAnimationCnt = 0f;
+                    if (_currentDemoPage == 4)
+                        _boundsAnimationCnt = 0f;
                     break;
                 }
 
                 case Key.Up:
                 {
-                    if (currentDemoPage == 4)
+                    if (_currentDemoPage == 4)
                     {
-                        if (cycleAlignment == QFontAlignment.Justify)
-                            cycleAlignment = QFontAlignment.Left;
+                        if (_cycleAlignment == QFontAlignment.Justify)
+                            _cycleAlignment = QFontAlignment.Left;
                         else
-                            cycleAlignment++;
+                            _cycleAlignment++;
                     }
                     break;
                 }
 
                 case Key.Down:
                 {
-                    if (currentDemoPage == 4)
+                    if (_currentDemoPage == 4)
                     {
-                        if (cycleAlignment == QFontAlignment.Left)
-                            cycleAlignment = QFontAlignment.Justify;
+                        if (_cycleAlignment == QFontAlignment.Left)
+                            _cycleAlignment = QFontAlignment.Justify;
                         else
-                            cycleAlignment--;
+                            _cycleAlignment--;
                     }
                     break;
                 }
@@ -209,10 +209,12 @@ namespace StarterKit
                     break;
             }
 
-            if (currentDemoPage > lastPage)
-                currentDemoPage = lastPage;
-            if (currentDemoPage < 0)
-                currentDemoPage = 0;
+            if (_currentDemoPage > _lastPage)
+                _currentDemoPage = _lastPage;
+            if (_currentDemoPage < 0)
+                _currentDemoPage = 0;
+
+			base.OnKeyDown(keyboardKeyEventArgs);
         }
 
         /// <summary>Load resources here.</summary>
@@ -221,37 +223,43 @@ namespace StarterKit
         {
             base.OnLoad(e);
 
-            this.Keyboard.KeyDown += KeyDown;
-            drawing = new QFontDrawing();
-            controlsDrawing = new QFontDrawing();
-            controlsTextOpts = new QFontRenderOptions() { Colour = Color.FromArgb(new Color4(0.8f, 0.1f, 0.1f, 1.0f).ToArgb()), DropShadowActive = true };
+            _drawing = new QFontDrawing();
+            _controlsDrawing = new QFontDrawing();
+            _controlsTextOpts = new QFontRenderOptions { Colour = Color.FromArgb(new Color4(0.8f, 0.1f, 0.1f, 1.0f).ToArgb()), DropShadowActive = true };
 
-            heading2 = new QFont("woodenFont.qfont", new QFontConfiguration(addDropShadow: true), 1.0f);
-            heading2Options = new QFontRenderOptions() { Colour = Color.White, DropShadowActive = true};
+            _heading2 = new QFont("woodenFont.qfont", new QFontConfiguration(true));
+            _heading2Options = new QFontRenderOptions { Colour = Color.White, DropShadowActive = true};
 
-            var builderConfig = new QFontBuilderConfiguration(addDropShadow: true);
-            builderConfig.ShadowConfig.blurRadius = 2; //reduce blur radius because font is very small
-            builderConfig.ShadowConfig.blurPasses = 1;
-            builderConfig.ShadowConfig.Type = ShadowType.Blurred;
-            builderConfig.TextGenerationRenderHint = TextGenerationRenderHint.ClearTypeGridFit; //best render hint for this font
-            builderConfig.Characters = CharacterSet.General | CharacterSet.Japanese | CharacterSet.Thai | CharacterSet.Cyrillic;
-            mainText = new QFont("Fonts/times.ttf", 14, builderConfig);
-            mainTextOptions = new QFontRenderOptions() { DropShadowActive = true, Colour = Color.White, WordSpacing = 0.5f};
+	        var builderConfig = new QFontBuilderConfiguration(true)
+	        {
+		        ShadowConfig =
+		        {
+			        blurRadius = 2,
+			        blurPasses = 1,
+			        Type = ShadowType.Blurred
+		        },
+		        TextGenerationRenderHint = TextGenerationRenderHint.ClearTypeGridFit,
+		        Characters = CharacterSet.General | CharacterSet.Japanese | CharacterSet.Thai | CharacterSet.Cyrillic
+	        };
+	        //reduce blur radius because font is very small
+	        //best render hint for this font
+	        _mainText = new QFont("Fonts/times.ttf", 14, builderConfig);
+            _mainTextOptions = new QFontRenderOptions { DropShadowActive = true, Colour = Color.White, WordSpacing = 0.5f};
  
             _benchmarkResults = new QFont("Fonts/times.ttf", 14, builderConfig);
 
-            heading1 = new QFont("Fonts/HappySans.ttf", 72, new QFontBuilderConfiguration(true));
+            _heading1 = new QFont("Fonts/HappySans.ttf", 72, new QFontBuilderConfiguration(true));
 
-            controlsText = new QFont("Fonts/HappySans.ttf", 32, new QFontBuilderConfiguration(true));
+            _controlsText = new QFont("Fonts/HappySans.ttf", 32, new QFontBuilderConfiguration(true));
 
-            codeText = new QFont("Fonts/Comfortaa-Regular.ttf", 12, new QFontBuilderConfiguration());
+            _codeText = new QFont("Fonts/Comfortaa-Regular.ttf", 12, new QFontBuilderConfiguration());
 
-            heading1Options = new QFontRenderOptions() { Colour = Color.FromArgb(new Color4(0.2f, 0.2f, 0.2f, 1.0f).ToArgb()), DropShadowActive = true};
-            _processedText = QFontDrawingPrimitive.ProcessText(mainText, mainTextOptions, preProcessed, new SizeF(Width - 40, -1), QFontAlignment.Left);
-            codeTextOptions = new QFontRenderOptions() { Colour = Color.FromArgb(new Color4(0.0f, 0.0f, 0.4f, 1.0f).ToArgb()) };
+            _heading1Options = new QFontRenderOptions { Colour = Color.FromArgb(new Color4(0.2f, 0.2f, 0.2f, 1.0f).ToArgb()), DropShadowActive = true};
+            _processedText = QFontDrawingPrimitive.ProcessText(_mainText, _mainTextOptions, _preProcessed, new SizeF(Width - 40, -1), QFontAlignment.Left);
+            _codeTextOptions = new QFontRenderOptions { Colour = Color.FromArgb(new Color4(0.0f, 0.0f, 0.4f, 1.0f).ToArgb()) };
 
-            monoSpaced = new QFont("Fonts/Anonymous.ttf", 10, new QFontBuilderConfiguration());
-            monoSpacedOptions = new QFontRenderOptions() { Colour = Color.FromArgb(new Color4(0.1f, 0.1f, 0.1f, 1.0f).ToArgb()), DropShadowActive = true};
+            _monoSpaced = new QFont("Fonts/Anonymous.ttf", 10, new QFontBuilderConfiguration());
+            _monoSpacedOptions = new QFontRenderOptions { Colour = Color.FromArgb(new Color4(0.1f, 0.1f, 0.1f, 1.0f).ToArgb()), DropShadowActive = true};
 
             // loop through some installed fonts and load them
             var ifc = new InstalledFontCollection();
@@ -281,20 +289,17 @@ namespace StarterKit
 
             GL.Viewport(ClientRectangle.X, ClientRectangle.Y, ClientRectangle.Width, ClientRectangle.Height);
 
-            //_projectionMatrix = Matrix4.CreateOrthographicOffCenter(X, Width, Y, Height, -1.0f, 1.0f);
             _projectionMatrix = Matrix4.CreateOrthographicOffCenter(ClientRectangle.X, ClientRectangle.Width, ClientRectangle.Y, ClientRectangle.Height, -1.0f, 1.0f);
-            //_projectionMatrix = Matrix4.Mult(Matrix4.CreateScale(1, -1.0f, 1), _projectionMatrix);
-            //_projectionMatrix = Matrix4.Mult(Matrix4.CreateScale(0.5f), _projectionMatrix);
         }
 
-        double cnt;
-        double boundsAnimationCnt = 1.0f;
-        private QFontRenderOptions monoSpacedOptions;
-        private QFontRenderOptions codeTextOptions;
-        private QFontRenderOptions mainTextOptions;
-        private QFontRenderOptions heading1Options;
-        private QFontRenderOptions heading2Options;
-        private QFontRenderOptions controlsTextOpts;
+	    private double _cnt;
+	    private double _boundsAnimationCnt = 1.0f;
+        private QFontRenderOptions _monoSpacedOptions;
+        private QFontRenderOptions _codeTextOptions;
+        private QFontRenderOptions _mainTextOptions;
+        private QFontRenderOptions _heading1Options;
+        private QFontRenderOptions _heading2Options;
+        private QFontRenderOptions _controlsTextOpts;
         private int _previousPage = -1;
 
         /// <summary>
@@ -308,30 +313,23 @@ namespace StarterKit
             if (Keyboard[Key.Escape])
                 Exit();
 
-            cnt += e.Time;
+            _cnt += e.Time;
 
-            if (boundsAnimationCnt < 1.0f)
-                boundsAnimationCnt += e.Time * 0.2f;
+            if (_boundsAnimationCnt < 1.0f)
+                _boundsAnimationCnt += e.Time * 0.2f;
             else
-                boundsAnimationCnt = 1.0f;
+                _boundsAnimationCnt = 1.0f;
         }
 
         private void PrintWithBounds(QFont font, string text, RectangleF bounds, QFontAlignment alignment, ref float yOffset)
         {
-            float maxWidth = bounds.Width;
+            var maxWidth = bounds.Width;
 
-            float height = font.Measure(text, new SizeF(maxWidth, -1), alignment).Height;
-
-            //gl.begin(beginmode.lineloop);
-            //gl.vertex3(bounds.x, bounds.y, 0f);
-            //gl.vertex3(bounds.x + bounds.width, bounds.y, 0f);
-            //gl.vertex3(bounds.x + bounds.width, bounds.y + height, 0f);
-            //gl.vertex3(bounds.x, bounds.y + height, 0f);
-            //gl.end();
+            var height = font.Measure(text, new SizeF(maxWidth, -1), alignment).Height;
 
             var dp = new QFontDrawingPrimitive(font);
             dp.Print(text, new Vector3(bounds.X, Height - yOffset, 0), new SizeF(maxWidth, float.MaxValue), alignment);
-            drawing.DrawingPrimitives.Add(dp);
+            _drawing.DrawingPrimitives.Add(dp);
 
             yOffset += height;
         }       
@@ -341,7 +339,7 @@ namespace StarterKit
 
         private void PrintComment(string comment, ref float yOffset)
         {
-            PrintComment(mainText, comment, QFontAlignment.Justify, ref yOffset, mainTextOptions);
+            PrintComment(_mainText, comment, QFontAlignment.Justify, ref yOffset, _mainTextOptions);
         }
 
         private void PrintComment(QFont font, string comment, QFontAlignment alignment, ref float yOffset, QFontRenderOptions opts )
@@ -351,40 +349,32 @@ namespace StarterKit
             var dp = new QFontDrawingPrimitive(font, opts ?? new QFontRenderOptions());
             dp.Print(comment, pos, new SizeF(Width - 60, -1), alignment);
             yOffset += dp.Measure(comment, new SizeF(Width - 60, -1), alignment).Height;
-            drawing.DrawingPrimitives.Add(dp);
+            _drawing.DrawingPrimitives.Add(dp);
         }
 
         private void PrintCommentWithLine(string comment, QFontAlignment alignment, float xOffset, ref float yOffset)
         {
-            PrintCommentWithLine(mainText, comment, alignment, xOffset, ref yOffset, mainTextOptions);
+            PrintCommentWithLine(_mainText, comment, alignment, xOffset, ref yOffset, _mainTextOptions);
         }
 
         private void PrintCommentWithLine(QFont font, string comment, QFontAlignment alignment, float xOffset, ref float yOffset, QFontRenderOptions opts)
         {
             yOffset += 20;
             var dp = new QFontDrawingPrimitive(font, opts);
-            //if (doSpacing)
-            //    dp.Options.CharacterSpacing = 0.05f;
-            dp.Print(comment, new Vector3(xOffset, Height - yOffset, 0f), new SizeF(Width - 60, -1), alignment);
-            drawing.DrawingPrimitives.Add(dp);
-            var bounds = font.Measure(comment, new SizeF(Width - 60, float.MaxValue), alignment);
 
-            //GL.Disable(EnableCap.Texture2D);
-            //GL.Begin(BeginMode.Lines);
-            //GL.Color4(1.0f, 0f, 0f, 1f); GL.Vertex2(0f, 0f);
-            //GL.Color4(1.0f, 0f, 0f, 1f); GL.Vertex2(0f, bounds.Height + 20f);
-            //GL.End();
+            dp.Print(comment, new Vector3(xOffset, Height - yOffset, 0f), new SizeF(Width - 60, -1), alignment);
+            _drawing.DrawingPrimitives.Add(dp);
+            var bounds = font.Measure(comment, new SizeF(Width - 60, float.MaxValue), alignment);
 
             yOffset += bounds.Height;
         }
 
-        
         private void PrintCode(string code, ref float yOffset)
         {
             yOffset += 20;
             var pos = new Vector3(50f, Height - yOffset, 0f);
-            drawing.Print(codeText, code, pos, new SizeF(Width - 50, -1), QFontAlignment.Left, codeTextOptions);
-            yOffset += codeText.Measure(code, new SizeF(Width - 50, -1), QFontAlignment.Left).Height;
+            _drawing.Print(_codeText, code, pos, new SizeF(Width - 50, -1), QFontAlignment.Left, _codeTextOptions);
+            yOffset += _codeText.Measure(code, new SizeF(Width - 50, -1), QFontAlignment.Left).Height;
         }
 
         /// <summary>
@@ -397,61 +387,51 @@ namespace StarterKit
 
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
-            drawing.ProjectionMatrix = _projectionMatrix;
+            _drawing.ProjectionMatrix = _projectionMatrix;
 
-            frameCount++;
+            _frameCount++;
 
             float yOffset = 0;
 
-            //mainText.Begin();
-            //GL.Begin(BeginMode.Quads);
- 
-            //GL.Color3(1.0f, 1.0f, 1.0); GL.Vertex2(0, 0);
-            //GL.Color3(0.9f, 0.9f, 0.9f); GL.Vertex2(0, Height);
-            //GL.Color3(0.9f, 0.9f, 0.9f); GL.Vertex2(Width, Height);
-            //GL.Color3(0.9f, 0.9f, 0.9f); GL.Vertex2(Width, 0);
-  
-            //GL.End();
-            //mainText.End();
-            if (currentDemoPage != _previousPage)
+            if (_currentDemoPage != _previousPage)
             {
-                _previousPage = currentDemoPage;
+                _previousPage = _currentDemoPage;
                 // we have to rebuild the stuff
-                drawing.DrawingPrimitives.Clear();
+                _drawing.DrawingPrimitives.Clear();
                             
-                switch (currentDemoPage)
+                switch (_currentDemoPage)
                 {
                     case 0:
                         {
-                            yOffset += drawing.Print(heading1, "ModernQuickFont",
+                            yOffset += _drawing.Print(_heading1, "ModernQuickFont",
                                                                      new Vector3((float) Width/2, Height, 0),
-                                                                     QFontAlignment.Centre, heading1Options).Height;
+                                                                     QFontAlignment.Centre, _heading1Options).Height;
 
-                            yOffset += drawing.Print(heading2, "Introduction #0",
+                            yOffset += _drawing.Print(_heading2, "Introduction #0",
                                                                      new Vector3(20, Height - yOffset, 0),
-                                                                     QFontAlignment.Left, heading2Options)
+                                                                     QFontAlignment.Left, _heading2Options)
                                         .Height;
 
-                            yOffset += drawing.Print(mainText, modernQuickFontIntro, new Vector3(30, Height - yOffset, 0),
+                            yOffset += _drawing.Print(_mainText, _modernQuickFontIntro, new Vector3(30, Height - yOffset, 0),
                                                                  new SizeF(Width - 60f, -1), QFontAlignment.Left).Height;
                             
-                            PrintCode(modernIntroCode, ref yOffset);
+                            PrintCode(_modernIntroCode, ref yOffset);
                             break;
                         }
 
                     case 1:
                         {
-                            yOffset += drawing.Print(heading1, "QuickFont",
+                            yOffset += _drawing.Print(_heading1, "QuickFont",
                                                                      new Vector3((float) Width/2, Height, 0),
-                                                                     QFontAlignment.Centre, heading1Options).Height;
+                                                                     QFontAlignment.Centre, _heading1Options).Height;
 
-                            yOffset += drawing.Print(heading2, "Introduction",
+                            yOffset += _drawing.Print(_heading2, "Introduction",
                                                                      new Vector3(20, Height - yOffset, 0),
-                                                                     QFontAlignment.Left, heading2Options)
+                                                                     QFontAlignment.Left, _heading2Options)
                                         .Height;
 
                             yOffset += 20f;
-                            drawing.Print(mainText, introduction, new Vector3(30, Height - yOffset, 0),
+                            _drawing.Print(_mainText, _introduction, new Vector3(30, Height - yOffset, 0),
                                                                  new SizeF(Width - 60f, -1), QFontAlignment.Justify);
                             
                             break;
@@ -459,37 +439,37 @@ namespace StarterKit
 
                     case 2:
                         {
-                            yOffset += drawing.Print( heading2, "Easy as ABC!",
+                            yOffset += _drawing.Print( _heading2, "Easy as ABC!",
                                                                      new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
-                            PrintComment(usingQuickFontIsSuperEasy, ref yOffset);
-                            PrintCode(loadingAFont1, ref yOffset);
+                            PrintComment(_usingQuickFontIsSuperEasy, ref yOffset);
+                            PrintCode(_loadingAFont1, ref yOffset);
 
-                            PrintComment(andPrintWithIt, ref yOffset);
-                            PrintCode(printWithFont1, ref yOffset);
+                            PrintComment(_andPrintWithIt, ref yOffset);
+                            PrintCode(_printWithFont1, ref yOffset);
 
-                            PrintComment(itIsAlsoEasyToMeasure, ref yOffset);
-                            PrintCode(measureText1, ref yOffset);
+                            PrintComment(_itIsAlsoEasyToMeasure, ref yOffset);
+                            PrintCode(_measureText1, ref yOffset);
 
                             PrintComment(oneOfTheFirstGotchas, ref yOffset);
-                            PrintCode(loadingAFont2, ref yOffset);
+                            PrintCode(_loadingAFont2, ref yOffset);
 
                             break;
                         }
 
                     case 3:
                         {
-                            yOffset +=  drawing.Print(heading2 ,"Alignment", new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                            yOffset +=  _drawing.Print(_heading2 ,"Alignment", new Vector3(20f, Height - yOffset, 0f),
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
-                            PrintCommentWithLine(whenPrintingText, QFontAlignment.Left, 20f, ref yOffset);
-                            PrintCode(printWithFont2, ref yOffset);
+                            PrintCommentWithLine(_whenPrintingText, QFontAlignment.Left, 20f, ref yOffset);
+                            PrintCode(_printWithFont2, ref yOffset);
 
-                            PrintCommentWithLine(righAlignedText, QFontAlignment.Right, 20f, ref yOffset);
+                            PrintCommentWithLine(_righAlignedText, QFontAlignment.Right, 20f, ref yOffset);
                             yOffset += 10f;
 
-                            PrintCommentWithLine(centredTextAsYou, QFontAlignment.Centre, Width*0.5f, ref yOffset);
+                            PrintCommentWithLine(_centredTextAsYou, QFontAlignment.Centre, Width*0.5f, ref yOffset);
 
                             break;
                         }
@@ -498,24 +478,24 @@ namespace StarterKit
                         {
                             // in this stage force redraw and recreation of VBO every time: just divert last page
                             _previousPage = -1;
-                            yOffset += drawing.Print(heading2, "Bounds and Justify",
+                            yOffset += _drawing.Print(_heading2, "Bounds and Justify",
                                                                      new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
                             yOffset += 20;
-                            yOffset +=  drawing.Print( controlsText, "Press [Up], [Down] or [Enter]!",
+                            yOffset +=  _drawing.Print( _controlsText, "Press [Up], [Down] or [Enter]!",
                                                                          new Vector3(Width*0.5f, Height - yOffset, 0f),
-                                                                         QFontAlignment.Centre, controlsTextOpts).Height;
+                                                                         QFontAlignment.Centre, _controlsTextOpts).Height;
 
-                            float boundShrink = (int) (350*(1 - Math.Cos(boundsAnimationCnt*Math.PI*2)));
+                            float boundShrink = (int) (350*(1 - Math.Cos(_boundsAnimationCnt*Math.PI*2)));
 
                             yOffset += 15;
-                            PrintWithBounds(mainText, ofCourseItsNot,
+                            PrintWithBounds(_mainText, _ofCourseItsNot,
                                             new RectangleF(30f + boundShrink*0.5f, yOffset, Width - 60 - boundShrink,
-                                                           350f), cycleAlignment, ref yOffset);
+                                                           350f), _cycleAlignment, ref yOffset);
 
                             string printWithBounds = "myFont.Print(text, position, maxSize, QFontAlignment." +
-                                                     cycleAlignment + ");";
+                                                     _cycleAlignment + ");";
                             yOffset += 15f;
                             PrintCode(printWithBounds, ref yOffset);
 
@@ -524,27 +504,27 @@ namespace StarterKit
 
                     case 5:
                         {
-                            yOffset +=  drawing.Print(heading2, "Your own Texture Fonts",
+                            yOffset +=  _drawing.Print(_heading2, "Your own Texture Fonts",
                                                                      new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
-                            PrintComment(anotherCoolFeature, ref yOffset);
-                            PrintCode(textureFontCode1, ref yOffset);
-                            PrintComment(thisWillHaveCreated, ref yOffset);
+                            PrintComment(_anotherCoolFeature, ref yOffset);
+                            PrintCode(_textureFontCode1, ref yOffset);
+                            PrintComment(_thisWillHaveCreated, ref yOffset);
 
                             break;
                         }
 
                     case 6:
                         {
-                            yOffset +=  drawing.Print(heading2, "Your own Texture Fonts",
+                            yOffset +=  _drawing.Print(_heading2, "Your own Texture Fonts",
                                                                      new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
-                            PrintComment(ifYouDoIntend, ref yOffset);
-                            PrintCode(textureFontCode2, ref yOffset);
-                            PrintComment(actuallyTexturing, ref yOffset);
-                            PrintCode(textureFontCode3, ref yOffset);
+                            PrintComment(_ifYouDoIntend, ref yOffset);
+                            PrintCode(_textureFontCode2, ref yOffset);
+                            PrintComment(_actuallyTexturing, ref yOffset);
+                            PrintCode(_textureFontCode3, ref yOffset);
 
                             break;
                         }
@@ -555,21 +535,26 @@ namespace StarterKit
                             _previousPage = -1;
 
                             // store this primitive to remember
-                            QFontDrawingPrimitive dp = new QFontDrawingPrimitive(heading2);
-                            dp.Options.DropShadowActive = true;
-                            dp.Options.DropShadowOffset = new Vector2(0.1f + 0.2f*(float) Math.Sin(cnt),
-                                                                            0.1f + 0.2f*(float) Math.Cos(cnt));
+	                        QFontDrawingPrimitive dp = new QFontDrawingPrimitive(_heading2)
+	                        {
+		                        Options =
+		                        {
+			                        DropShadowActive = true,
+			                        DropShadowOffset = new Vector2(0.1f + 0.2f*(float) Math.Sin(_cnt),
+				                        0.1f + 0.2f*(float) Math.Cos(_cnt))
+		                        }
+	                        };
 
-                            yOffset += dp.Print("Drop Shadows",
+	                        yOffset += dp.Print("Drop Shadows",
                                                                      new Vector3(20f, Height - yOffset, 0f),
                                                                      QFontAlignment.Left).Height;
-                            drawing.DrawingPrimitives.Add(dp);
+                            _drawing.DrawingPrimitives.Add(dp);
 
-                            PrintComment(asIhaveleant, ref yOffset);
-                            PrintCode(dropShadowCode1, ref yOffset);
-                            PrintComment(thisWorksFine, ref yOffset);
-                            PrintCode(dropShadowCode2, ref yOffset);
-                            PrintComment(onceAFont, ref yOffset);
+                            PrintComment(_asIhaveleant, ref yOffset);
+                            PrintCode(_dropShadowCode1, ref yOffset);
+                            PrintComment(_thisWorksFine, ref yOffset);
+                            PrintCode(_dropShadowCode2, ref yOffset);
+                            PrintComment(_onceAFont, ref yOffset);
 
                             //mainText.Options.DropShadowActive = false;
                             break;
@@ -577,24 +562,24 @@ namespace StarterKit
 
                     case 8:
                         {
-                            yOffset += drawing.Print(heading2, "Monospaced Fonts",
+                            yOffset += _drawing.Print(_heading2, "Monospaced Fonts",
                                                                      new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
-                            QFontRenderOptions monoSpaceCondensed = monoSpacedOptions.CreateClone();
+                            QFontRenderOptions monoSpaceCondensed = _monoSpacedOptions.CreateClone();
                             monoSpaceCondensed.CharacterSpacing = 0.05f;
-                            PrintComment(monoSpaced, hereIsSomeMono, QFontAlignment.Left, ref yOffset, monoSpaceCondensed);
-                            PrintCode(monoCode1, ref yOffset);
-                            PrintComment(monoSpaced, theDefaultMono, QFontAlignment.Left, ref yOffset, monoSpaceCondensed);
+                            PrintComment(_monoSpaced, _hereIsSomeMono, QFontAlignment.Left, ref yOffset, monoSpaceCondensed);
+                            PrintCode(_monoCode1, ref yOffset);
+                            PrintComment(_monoSpaced, _theDefaultMono, QFontAlignment.Left, ref yOffset, monoSpaceCondensed);
 
-                            PrintCommentWithLine(monoSpaced, mono, QFontAlignment.Left, 20f, ref yOffset, monoSpaceCondensed);
+                            PrintCommentWithLine(_monoSpaced, _mono, QFontAlignment.Left, 20f, ref yOffset, monoSpaceCondensed);
                             yOffset += 2f;
-                            PrintCommentWithLine(monoSpaced, mono, QFontAlignment.Right, 20f, ref yOffset, monoSpaceCondensed);
+                            PrintCommentWithLine(_monoSpaced, _mono, QFontAlignment.Right, 20f, ref yOffset, monoSpaceCondensed);
                             yOffset += 2f;
-                            PrintCommentWithLine(monoSpaced, mono, QFontAlignment.Centre, Width * 0.5f, ref yOffset, monoSpaceCondensed);
+                            PrintCommentWithLine(_monoSpaced, _mono, QFontAlignment.Centre, Width * 0.5f, ref yOffset, monoSpaceCondensed);
                             yOffset += 2f;
 
-                            PrintComment(monoSpaced,
+                            PrintComment(_monoSpaced,
                                          "As usual, you can adjust character spacing with myPrimitive.Options.CharacterSpacing.",
                                          QFontAlignment.Left, ref yOffset, monoSpaceCondensed);
 
@@ -606,34 +591,34 @@ namespace StarterKit
                         {
                             // in this stage force redraw and recreation of VBO every time: just divert last page
                             _previousPage = -1;
-                            yOffset += drawing.Print(heading2, "Preprocessed Text",
+                            yOffset += _drawing.Print(_heading2, "Preprocessed Text",
                                                                      new Vector3(20f, Height - yOffset, 0f),
                                                                      QFontAlignment.Left).Height;
                             yOffset += 20f;
 
                             _stopwatch = Stopwatch.StartNew();
-                            yOffset +=  drawing.Print(mainText, _processedText,
+                            yOffset +=  _drawing.Print(_mainText, _processedText,
                                                                      new Vector3(20, Height - yOffset, 0)).Height;
                             _stopwatch.Stop();
                             long preprocessed = _stopwatch.Elapsed.Ticks;
 
                             _stopwatch = Stopwatch.StartNew();
-                            yOffset += drawing.Print( mainText,nonPreProcessed,
+                            yOffset += _drawing.Print( _mainText,_nonPreProcessed,
                                                                      new Vector3(20, Height - yOffset, 0),
                                                                      new SizeF(Width - 40f, -1), QFontAlignment.Left)
                                         .Height;
                             _stopwatch.Stop();
                             long notpreprocessed = _stopwatch.Elapsed.Ticks;
 
-                            if (frameCount > 60)
+                            if (_frameCount > 60)
                             {
                                 _benchResult = string.Format(("{0}       {1}\nPreprocessed was {2} ticks faster"),
                                                              preprocessed,
                                                              notpreprocessed, notpreprocessed - preprocessed);
-                                frameCount = 0;
+                                _frameCount = 0;
                             }
 
-                            drawing.Print(_benchmarkResults, _benchResult,
+                            _drawing.Print(_benchmarkResults, _benchResult,
                                                                           new Vector3(Width*0.5f, Height - yOffset, 0),
                                                                           QFontAlignment.Centre, Color.White);
                             break;
@@ -641,24 +626,24 @@ namespace StarterKit
 
                     case 10:
                         {
-                            yOffset += drawing.Print(heading2, "In Conclusion",
+                            yOffset += _drawing.Print(_heading2, "In Conclusion",
                                                                      new Vector3(20f, Height - yOffset, 0f),
-                                                                     QFontAlignment.Left, heading2Options).Height;
+                                                                     QFontAlignment.Left, _heading2Options).Height;
 
-                            PrintComment(thereAreActually, ref yOffset);
+                            PrintComment(_thereAreActually, ref yOffset);
 
                             break;
                         }
 
                     case 11:
                     {
-                        yOffset += drawing.Print(heading2, "Different installed fonts",
+                        yOffset += _drawing.Print(_heading2, "Different installed fonts",
                             new Vector3(20f, Height - yOffset, 0f),
-                            QFontAlignment.Left, heading2Options).Height + 20;
+                            QFontAlignment.Left, _heading2Options).Height + 20;
 
                         foreach (var qFont in _installedFonts)
                         {
-                            yOffset += drawing.Print(qFont, "This text is printed with " + qFont.FontName,
+                            yOffset += _drawing.Print(qFont, "This text is printed with " + qFont.FontName,
                                 new Vector3(20f, Height - yOffset, 0), QFontAlignment.Left, Color.White).Height + 10;
                         }
 
@@ -666,31 +651,31 @@ namespace StarterKit
                     }
                 }
 
-                drawing.RefreshBuffers();
+                _drawing.RefreshBuffers();
 
             }
 
             // Create controlsDrawing every time.. would be also good to vary ProjectionMatrix with * Matrix4.CreateTranslation() !
             // this would save buffer work for OpenGL
-            controlsDrawing.DrawingPrimitives.Clear();
-            controlsDrawing.ProjectionMatrix = _projectionMatrix;
+            _controlsDrawing.DrawingPrimitives.Clear();
+            _controlsDrawing.ProjectionMatrix = _projectionMatrix;
 
-            if (currentDemoPage != lastPage)
+            if (_currentDemoPage != _lastPage)
             {
-                Vector3 pos = new Vector3(Width - 10 - 16 * (float)(1 + Math.Sin(cnt * 4)), 
-                    controlsText.Measure("P").Height + 10f, 0f);
-                controlsDrawing.Print(controlsText, "Press [Right] ->", pos, QFontAlignment.Right, controlsTextOpts);
+                Vector3 pos = new Vector3(Width - 10 - 16 * (float)(1 + Math.Sin(_cnt * 4)), 
+                    _controlsText.Measure("P").Height + 10f, 0f);
+                _controlsDrawing.Print(_controlsText, "Press [Right] ->", pos, QFontAlignment.Right, _controlsTextOpts);
             }
 
-            if (currentDemoPage != 0)
+            if (_currentDemoPage != 0)
             {
-                var pos = new Vector3(10 + 16*(float) (1 + Math.Sin(cnt*4)), controlsText.Measure("P").Height + 10f, 0f);
-                controlsDrawing.Print(controlsText, "<- Press [Left]", pos, QFontAlignment.Left, controlsTextOpts);
+                var pos = new Vector3(10 + 16*(float) (1 + Math.Sin(_cnt*4)), _controlsText.Measure("P").Height + 10f, 0f);
+                _controlsDrawing.Print(_controlsText, "<- Press [Left]", pos, QFontAlignment.Left, _controlsTextOpts);
             }
-            controlsDrawing.RefreshBuffers();
-            controlsDrawing.Draw();
+            _controlsDrawing.RefreshBuffers();
+            _controlsDrawing.Draw();
 
-            drawing.Draw();
+            _drawing.Draw();
             SwapBuffers();
         }
 

--- a/Example/Properties/AssemblyInfo.cs
+++ b/Example/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/Example/Properties/AssemblyInfo.cs
+++ b/Example/Properties/AssemblyInfo.cs
@@ -4,11 +4,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Example")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyTitle("QuickFont.Example")]
+[assembly: AssemblyDescription("The QuickFont Example Project")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("GitHub")]
-[assembly: AssemblyProduct("Example")]
+[assembly: AssemblyCompany("QuickFont")]
+[assembly: AssemblyProduct("QuickFont.Example")]
 [assembly: AssemblyCopyright("Copyright © QuickFont contributors 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.1.*")]
+[assembly: AssemblyVersion("4.3.*")]

--- a/QuickFont.Desktop/Properties/AssemblyInfo.cs
+++ b/QuickFont.Desktop/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.*")]
+[assembly: AssemblyVersion("4.3.*")]

--- a/QuickFont.Desktop/QuickFont.Desktop.csproj
+++ b/QuickFont.Desktop/QuickFont.Desktop.csproj
@@ -31,6 +31,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DocumentationFile>bin\Debug\QuickFont.XML</DocumentationFile>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -41,6 +42,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>bin\Release\QuickFont.XML</DocumentationFile>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">

--- a/QuickFont.ES20/Properties/AssemblyInfo.cs
+++ b/QuickFont.ES20/Properties/AssemblyInfo.cs
@@ -31,4 +31,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("4.2.*")]
+[assembly: AssemblyVersion("4.3.*")]

--- a/QuickFont.Shared/Builder.cs
+++ b/QuickFont.Shared/Builder.cs
@@ -20,7 +20,7 @@ namespace QuickFont
 
         public Builder(IFont font, QFontBuilderConfiguration config)
         {
-            this.charSet = config.charSet;
+            this.charSet = config.CharSet;
             this.config = config;
             this.font = font;
             
@@ -482,7 +482,7 @@ namespace QuickFont
             int minYOffset = int.MaxValue;
             foreach (var glyph in initialGlyphs)
             {
-                RetargetGlyphRectangleInwards(initialBitmapData, glyph, true, config.KerningConfig.alphaEmptyPixelTolerance);
+                RetargetGlyphRectangleInwards(initialBitmapData, glyph, true, config.KerningConfig.AlphaEmptyPixelTolerance);
                 minYOffset = Math.Min(minYOffset,glyph.yOffset);
             }
             minYOffset--; //give one pixel of breathing room?
@@ -500,7 +500,7 @@ namespace QuickFont
             if (config.SuperSampleLevels != 1)
             {
                 ScaleSheetsAndGlyphs(bitmapPages, glyphs, 1.0f / config.SuperSampleLevels);
-                RetargetAllGlyphs(bitmapPages, glyphs,config.KerningConfig.alphaEmptyPixelTolerance);
+                RetargetAllGlyphs(bitmapPages, glyphs,config.KerningConfig.AlphaEmptyPixelTolerance);
             }
 
             //create list of texture pages
@@ -536,7 +536,7 @@ namespace QuickFont
             }
 
             if (config.ShadowConfig != null)
-                fontData.dropShadowFont = BuildDropShadow(bitmapPages, glyphs, config.ShadowConfig, charSet.ToCharArray(),config.KerningConfig.alphaEmptyPixelTolerance);
+                fontData.dropShadowFont = BuildDropShadow(bitmapPages, glyphs, config.ShadowConfig, charSet.ToCharArray(),config.KerningConfig.AlphaEmptyPixelTolerance);
 
             foreach (var page in bitmapPages)
                 page.Free();
@@ -563,7 +563,7 @@ namespace QuickFont
             foreach(var sourceSheet in sourceFontSheets)
                 sourceBitmapData.Add(sourceSheet.bitmapData);
             
-            var bitmapSheets = GenerateBitmapSheetsAndRepack(sourceFontGlyphs, sourceBitmapData.ToArray(), shadowConfig.PageMaxTextureSize, shadowConfig.PageMaxTextureSize, out newGlyphs, shadowConfig.GlyphMargin + shadowConfig.blurRadius*3);
+            var bitmapSheets = GenerateBitmapSheetsAndRepack(sourceFontGlyphs, sourceBitmapData.ToArray(), shadowConfig.PageMaxTextureSize, shadowConfig.PageMaxTextureSize, out newGlyphs, shadowConfig.GlyphMargin + shadowConfig.BlurRadius*3);
 
             //scale up in case we wanted bigger/smaller shadows
             if (shadowConfig.Scale != 1.0f)
@@ -574,9 +574,9 @@ namespace QuickFont
             {
                 bitmapSheet.Colour32(255, 255, 255);
                 if (shadowConfig.Type == ShadowType.Blurred)
-                    bitmapSheet.BlurAlpha(shadowConfig.blurRadius, shadowConfig.blurPasses);
+                    bitmapSheet.BlurAlpha(shadowConfig.BlurRadius, shadowConfig.BlurPasses);
                 else
-                    bitmapSheet.ExpandAlpha(shadowConfig.blurRadius, shadowConfig.blurPasses);
+                    bitmapSheet.ExpandAlpha(shadowConfig.BlurRadius, shadowConfig.BlurPasses);
             }
 
             //retarget after blur and scale
@@ -671,7 +671,7 @@ namespace QuickFont
             }
 
             foreach (var glyph in data.CharSetMapping.Values)
-                RetargetGlyphRectangleOutwards(bitmapPages[glyph.page].bitmapData, glyph, false, loaderConfig.KerningConfig.alphaEmptyPixelTolerance);
+                RetargetGlyphRectangleOutwards(bitmapPages[glyph.page].bitmapData, glyph, false, loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
  
             var intercept = FirstIntercept(data.CharSetMapping);
             if (intercept != null)
@@ -741,7 +741,7 @@ namespace QuickFont
             if (downSampleFactor != 1.0f)
             {
                 foreach (var glyph in data.CharSetMapping.Values)
-                    RetargetGlyphRectangleOutwards(bitmapPages[glyph.page].bitmapData, glyph, false, loaderConfig.KerningConfig.alphaEmptyPixelTolerance);
+                    RetargetGlyphRectangleOutwards(bitmapPages[glyph.page].bitmapData, glyph, false, loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
 
                 intercept = FirstIntercept(data.CharSetMapping);
                 if (intercept != null)
@@ -756,7 +756,7 @@ namespace QuickFont
                 glyphList.Add(data.CharSetMapping[c]);
 
             if (loaderConfig.ShadowConfig != null)
-                data.dropShadowFont = BuildDropShadow(bitmapPages, glyphList.ToArray(), loaderConfig.ShadowConfig, Helper.ToArray(charSet),loaderConfig.KerningConfig.alphaEmptyPixelTolerance);
+                data.dropShadowFont = BuildDropShadow(bitmapPages, glyphList.ToArray(), loaderConfig.ShadowConfig, Helper.ToArray(charSet),loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
 
             data.KerningPairs = KerningCalculator.CalculateKerning(Helper.ToArray(charSet), glyphList.ToArray(), bitmapPages, loaderConfig.KerningConfig);
             

--- a/QuickFont.Shared/Builder.cs
+++ b/QuickFont.Shared/Builder.cs
@@ -30,7 +30,7 @@ namespace QuickFont
         {
             var dict = new Dictionary<char, QFontGlyph>();
             for (int i = 0; i < glyphs.Length; i++)
-                dict.Add(glyphs[i].character, glyphs[i]);
+                dict.Add(glyphs[i].Character, glyphs[i]);
 
             return dict;
         }
@@ -49,10 +49,10 @@ namespace QuickFont
             Graphics graph = Graphics.FromImage(bmp);
             List<SizeF> sizes = new List<SizeF>();
 
-            for (int i = 0; i < _charSet.Length; i++)
+            foreach (char t in _charSet)
             {
-                var charSize = font.MeasureString("" + _charSet[i], graph);
-                sizes.Add(new SizeF(charSize.Width+padding, charSize.Height+padding));
+	            var charSize = font.MeasureString("" + t, graph);
+	            sizes.Add(new SizeF(charSize.Width+padding, charSize.Height+padding));
             }
 
             graph.Dispose();
@@ -61,6 +61,11 @@ namespace QuickFont
             return sizes;
         }
 
+		/// <summary>
+		/// Returns the maximum width and maximum height from the list of sizes
+		/// </summary>
+		/// <param name="sizes"></param>
+		/// <returns></returns>
         private SizeF GetMaxGlyphSize(List<SizeF> sizes)
         {
             SizeF maxSize = new SizeF(0f, 0f);
@@ -76,6 +81,11 @@ namespace QuickFont
             return maxSize;
         }
 
+		/// <summary>
+		/// Returns the minimum width and minimum height from the list of sizes
+		/// </summary>
+		/// <param name="sizes"></param>
+		/// <returns></returns>
         private SizeF GetMinGlyphSize(List<SizeF> sizes)
         {
             SizeF minSize = new SizeF(float.MaxValue, float.MaxValue);
@@ -107,31 +117,15 @@ namespace QuickFont
             return false;
         }
 
-        /*
-        private SizeF GetMaxGlyphSize(Font font)
-        {
-            Bitmap bmp = new Bitmap(256, 256, PixelFormat.Format24bppRgb);
-            Graphics graph = Graphics.FromImage(bmp);
-
-            SizeF maxSize = new SizeF(0f, 0f);
-            for (int i = 0; i < charSet.Length; i++)
-            {
-                var charSize = graph.MeasureString("" + charSet[i], font);
-
-                if (charSize.Width > maxSize.Width)
-                    maxSize.Width = charSize.Width;
-
-                if (charSize.Height > maxSize.Height)
-                    maxSize.Height = charSize.Height;
-            }
-
-            graph.Dispose();
-            bmp.Dispose();
-
-            return maxSize;
-        }*/
-
-        //The initial bitmap is simply a long thin strip of all glyphs in a row
+		/// <summary>
+		/// Creates the initial font bitmap. This is simply a long thin strip of all glyphs in a row
+		/// </summary>
+		/// <param name="font">The <see cref="IFont"/> object to build the initial bitmap from</param>
+		/// <param name="maxSize">The maximum glyph size of the font</param>
+		/// <param name="initialMargin">The initial bitmap margin (used for all four sides)</param>
+		/// <param name="glyphs">A collection of <see cref="QFontGlyph"/>s corresponding to the initial bitmap</param>
+		/// <param name="renderHint">The font rendering hint to use</param>
+		/// <returns></returns>
         private Bitmap CreateInitialBitmap(IFont font, SizeF maxSize, int initialMargin, out QFontGlyph[] glyphs, TextGenerationRenderHint renderHint)
         {
             glyphs = new QFontGlyph[_charSet.Length];
@@ -180,12 +174,20 @@ namespace QuickFont
 
         private delegate bool EmptyDel(BitmapData data, int x, int y);
 
+		/// <summary>
+		/// Retargets a given glyph rectangle inwards, to find the minimum bounding box
+		/// Assumes the current bounding box is larger than the minimum
+		/// </summary>
+		/// <param name="bitmapData">The bitmap containing the glyph</param>
+		/// <param name="glyph">The <see cref="QFontGlyph"/> to retarget</param>
+		/// <param name="setYOffset">Whether to update the y offset of the glyph or not</param>
+		/// <param name="alphaTolerance">The alpha tolerance</param>
         private static void RetargetGlyphRectangleInwards(BitmapData bitmapData, QFontGlyph glyph, bool setYOffset, byte alphaTolerance)
         {
             int startX, endX;
             int startY, endY;
 
-            var rect = glyph.rect;
+            var rect = glyph.Rect;
 
             EmptyDel emptyPix;
 
@@ -194,52 +196,57 @@ namespace QuickFont
             else
                 emptyPix = delegate(BitmapData data, int x, int y) { return QBitmap.EmptyPixel(data, x, y); };
 
-            unsafe
-            {
-                for (startX = rect.X; startX < bitmapData.Width; startX++)
-                    for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
-                        if (!emptyPix(bitmapData, startX, j))
-                            goto Done1;
-                Done1:
+			for (startX = rect.X; startX < bitmapData.Width; startX++)
+				for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
+					if (!emptyPix(bitmapData, startX, j))
+						goto Done1;
+			Done1:
 
-                for (endX = rect.X + rect.Width; endX >= 0; endX--)
-                    for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
-                        if (!emptyPix(bitmapData, endX, j))
-                            goto Done2;
-                Done2:
+			for (endX = rect.X + rect.Width; endX >= 0; endX--)
+				for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
+					if (!emptyPix(bitmapData, endX, j))
+						goto Done2;
+			Done2:
 
-                for (startY = rect.Y; startY < bitmapData.Height; startY++)
-                    for (int i = startX; i <= endX; i++)
-                        if (!emptyPix(bitmapData, i, startY))
-                            goto Done3;
+			for (startY = rect.Y; startY < bitmapData.Height; startY++)
+				for (int i = startX; i <= endX; i++)
+					if (!emptyPix(bitmapData, i, startY))
+						goto Done3;
                             
-                Done3:
+			Done3:
 
-                for (endY = rect.Y + rect.Height; endY >= 0; endY--)
-                    for (int i = startX; i <= endX; i++)
-                        if (!emptyPix(bitmapData, i, endY))
-                            goto Done4;
-                Done4:;
-            }
+			for (endY = rect.Y + rect.Height; endY >= 0; endY--)
+				for (int i = startX; i <= endX; i++)
+					if (!emptyPix(bitmapData, i, endY))
+						goto Done4;
+			Done4:
 
-            if (endY < startY)
+			if (endY < startY)
                 startY = endY = rect.Y;
 
             if (endX < startX)
                 startX = endX = rect.X;
 
-            glyph.rect = new Rectangle(startX, startY, endX - startX + 1, endY - startY + 1);
+            glyph.Rect = new Rectangle(startX, startY, endX - startX + 1, endY - startY + 1);
 
             if (setYOffset)
-                glyph.yOffset = glyph.rect.Y;
+                glyph.YOffset = glyph.Rect.Y;
         }
 
-        private static void RetargetGlyphRectangleOutwards(BitmapData bitmapData, QFontGlyph glyph, bool setYOffset, byte alphaTolerance)
+		/// <summary>
+		/// Retargets a given glyph rectangle outwards, to find the minimum bounding box
+		/// Assumes the current bounding box is smaller than the minimum
+		/// </summary>
+		/// <param name="bitmapData">The bitmap containing the glyph</param>
+		/// <param name="glyph">The <see cref="QFontGlyph"/> to retarget</param>
+		/// <param name="setYOffset">Whether to update the y offset of the glyph or not</param>
+		/// <param name="alphaTolerance">The alpha tolerance</param>
+		private static void RetargetGlyphRectangleOutwards(BitmapData bitmapData, QFontGlyph glyph, bool setYOffset, byte alphaTolerance)
         {
             int startX,endX;
             int startY,endY;
 
-            var rect = glyph.rect;
+            var rect = glyph.Rect;
 
             EmptyDel emptyPix;
 
@@ -248,91 +255,98 @@ namespace QuickFont
             else
                 emptyPix = delegate(BitmapData data, int x, int y) { return QBitmap.EmptyPixel(data, x, y); };
 
-            unsafe
-            {
-                for (startX = rect.X; startX >= 0; startX--)
-                {
-                    bool foundPix = false;
-                    for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
-                    {
-                        if (!emptyPix(bitmapData, startX, j))
-                        {
-                            foundPix = true;
-                            break;
-                        }
-                    }
+			for (startX = rect.X; startX >= 0; startX--)
+			{
+				bool foundPix = false;
+				for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
+				{
+					if (!emptyPix(bitmapData, startX, j))
+					{
+						foundPix = true;
+						break;
+					}
+				}
 
-                    if (!foundPix)
-                    {
-                        startX++;
-                        break;
-                    }
-                }
+				if (!foundPix)
+				{
+					startX++;
+					break;
+				}
+			}
 
-                for (endX = rect.X + rect.Width; endX < bitmapData.Width; endX++)
-                {
-                    bool foundPix = false;
-                    for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
-                    {
-                        if (!emptyPix(bitmapData, endX, j))
-                        {
-                            foundPix = true;
-                            break; 
-                        }
-                    }
+			for (endX = rect.X + rect.Width; endX < bitmapData.Width; endX++)
+			{
+				bool foundPix = false;
+				for (int j = rect.Y; j <= rect.Y + rect.Height; j++)
+				{
+					if (!emptyPix(bitmapData, endX, j))
+					{
+						foundPix = true;
+						break; 
+					}
+				}
 
-                    if (!foundPix)
-                    {
-                        endX--;
-                        break;
-                    }
-                }
+				if (!foundPix)
+				{
+					endX--;
+					break;
+				}
+			}
 
-                for (startY = rect.Y; startY >= 0; startY--)
-                {
-                    bool foundPix = false;
-                    for (int i = startX; i <= endX; i++)
-                    {
-                        if (!emptyPix(bitmapData, i, startY))
-                        {
-                            foundPix = true;
-                            break;
-                        }
-                    }
+			for (startY = rect.Y; startY >= 0; startY--)
+			{
+				bool foundPix = false;
+				for (int i = startX; i <= endX; i++)
+				{
+					if (!emptyPix(bitmapData, i, startY))
+					{
+						foundPix = true;
+						break;
+					}
+				}
 
-                    if (!foundPix)
-                    {
-                        startY++;
-                        break;
-                    }
-                }
+				if (!foundPix)
+				{
+					startY++;
+					break;
+				}
+			}
 
-                for (endY = rect.Y + rect.Height; endY < bitmapData.Height; endY++)
-                {
-                    bool foundPix = false;
-                    for (int i = startX; i <= endX; i++)
-                    {
-                        if (!emptyPix(bitmapData, i, endY))
-                        {
-                            foundPix = true;
-                            break;
-                        }
-                    }
+			for (endY = rect.Y + rect.Height; endY < bitmapData.Height; endY++)
+			{
+				bool foundPix = false;
+				for (int i = startX; i <= endX; i++)
+				{
+					if (!emptyPix(bitmapData, i, endY))
+					{
+						foundPix = true;
+						break;
+					}
+				}
 
-                    if (!foundPix)
-                    {
-                        endY--;
-                        break;
-                    }
-                }
-            }
+				if (!foundPix)
+				{
+					endY--;
+					break;
+				}
+			}
 
-            glyph.rect = new Rectangle(startX, startY, endX - startX + 1, endY - startY + 1);
+			glyph.Rect = new Rectangle(startX, startY, endX - startX + 1, endY - startY + 1);
 
             if (setYOffset)
-                glyph.yOffset = glyph.rect.Y;
+                glyph.YOffset = glyph.Rect.Y;
         }
 
+		/// <summary>
+		/// Generates the final bitmap sheet for the font
+		/// </summary>
+		/// <param name="sourceGlyphs">A collection of <see cref="QFontGlyph"/>s. These are written to the final bitmap</param>
+		/// <param name="sourceBitmaps"> The source bitmaps for the font (initial bitmap)</param>
+		/// <param name="destSheetWidth">The destination bitmap width</param>
+		/// <param name="destSheetHeight">The destination bitmap height</param>
+		/// <param name="destGlyphs">A collection of <see cref="QFontGlyph"/>s that are placed on the final bitmap sheet</param>
+		/// <param name="destMargin">The margin for the final bitmap sheet</param>
+		/// <returns>A collection of <see cref="QBitmap"/>s. These are the final bitmap sheets</returns>
         private static List<QBitmap> GenerateBitmapSheetsAndRepack(QFontGlyph[] sourceGlyphs, BitmapData[] sourceBitmaps, int destSheetWidth, int destSheetHeight, out QFontGlyph[] destGlyphs, int destMargin)
         {
             var pages = new List<QBitmap>();
@@ -342,23 +356,28 @@ namespace QuickFont
 
             int maxY = 0;
             foreach (var glph in sourceGlyphs)
-                maxY = Math.Max(glph.rect.Height, maxY);
+                maxY = Math.Max(glph.Rect.Height, maxY);
 
             int finalPageIndex = 0;
             int finalPageRequiredWidth = 0;
             int finalPageRequiredHeight = 0;
             
+			// We loop through the whole process twice. The first time is to determine
+			// the size of the final page, so that we can crop it in advance
             for (int k = 0; k < 2; k++)
             {
-                bool pre = k == 0;  //first iteration is simply to determine the required size of the final page, so that we can crop it in advance
+				// Whether this is the pre-processing step
+                bool pre = k == 0; 
 
                 int xPos = 0;
                 int yPos = 0;
                 int maxYInRow = 0;
                 int totalTries = 0;
 
+				// Loop through all the glyphs
                 for (int i = 0; i < sourceGlyphs.Length; i++)
                 {
+					// If this is the second stage and we don't already have a bitmap page, create one
                     if(!pre && currentPage == null){
 
                         if (finalPageIndex == pages.Count)
@@ -377,62 +396,78 @@ namespace QuickFont
                         pages.Add(currentPage);
                     }
 
+					// Keep track of the number of times we've tried to fit the font onto the texture page
                     totalTries++;
 
                     if (totalTries > 10 * sourceGlyphs.Length)
                         throw new Exception("Failed to fit font into texture pages");
 
-                    var rect = sourceGlyphs[i].rect;
+                    var rect = sourceGlyphs[i].Rect;
 
+					// If we can fit the glyph onto the page, place it
                     if (xPos + rect.Width + 2 * destMargin <= destSheetWidth && yPos + rect.Height + 2 * destMargin <= destSheetHeight)
                     {
                         if (!pre)
                         {
-                            //add to page
-                            if(sourceBitmaps[sourceGlyphs[i].page].PixelFormat == PixelFormat.Format32bppArgb)
-                                QBitmap.Blit(sourceBitmaps[sourceGlyphs[i].page], currentPage.bitmapData, rect.X, rect.Y, rect.Width, rect.Height, xPos + destMargin, yPos + destMargin);
+                            // Add to page
+                            if(sourceBitmaps[sourceGlyphs[i].Page].PixelFormat == PixelFormat.Format32bppArgb)
+                                QBitmap.Blit(sourceBitmaps[sourceGlyphs[i].Page], currentPage.BitmapData, rect.X, rect.Y, rect.Width, rect.Height, xPos + destMargin, yPos + destMargin);
                             else
-                                QBitmap.BlitMask(sourceBitmaps[sourceGlyphs[i].page], currentPage.bitmapData, rect.X, rect.Y, rect.Width, rect.Height, xPos + destMargin, yPos + destMargin);
+                                QBitmap.BlitMask(sourceBitmaps[sourceGlyphs[i].Page], currentPage.BitmapData, rect.X, rect.Y, rect.Width, rect.Height, xPos + destMargin, yPos + destMargin);
 
-                            destGlyphs[i] = new QFontGlyph(pages.Count - 1, new Rectangle(xPos + destMargin, yPos + destMargin, rect.Width, rect.Height), sourceGlyphs[i].yOffset, sourceGlyphs[i].character);
+							// Add to destination glyph collection
+                            destGlyphs[i] = new QFontGlyph(pages.Count - 1, new Rectangle(xPos + destMargin, yPos + destMargin, rect.Width, rect.Height), sourceGlyphs[i].YOffset, sourceGlyphs[i].Character);
                         }
                         else
                         {
+							// Update the final dimensions
                             finalPageRequiredWidth = Math.Max(finalPageRequiredWidth, xPos + rect.Width + 2 * destMargin);
                             finalPageRequiredHeight = Math.Max(finalPageRequiredHeight, yPos + rect.Height + 2 * destMargin);
                         }
 
+						// Update the current x position
                         xPos += rect.Width + 2 * destMargin;
+
+						// Update the maximum row height so far
                         maxYInRow = Math.Max(maxYInRow, rect.Height);
 
                         continue;
                     }
 
+					// If we reach this, haven't been able to fit glyph onto row
+					// Move down one row and try again
                     if (xPos + rect.Width + 2 * destMargin > destSheetWidth)
                     {
+						// Retry the current glyph on the next row
                         i--;
 
+						// Change coordinates to next row
                         yPos += maxYInRow + 2 * destMargin;
                         xPos = 0;
 
+						// Is the next row off the bitmap sheet?
                         if (yPos + maxY + 2 * destMargin > destSheetHeight)
                         {
+							// Reset y position
                             yPos = 0;
 
                             if (!pre)
                             {
+								// If this is not the second stage, reset the currentPage
+								// This will create a new one on next loop
                                 currentPage = null;
                             }
                             else
                             {
+								// If this is the pre-processing stage, update
+								// the finalPageIndex. Reset width and height
+								// since we clearly need one full page and extra
                                 finalPageRequiredWidth = 0;
                                 finalPageRequiredHeight = 0;
                                 finalPageIndex++;
                             }
                         }
-                        continue;
                     }
-
                 }
 
             }
@@ -440,13 +475,14 @@ namespace QuickFont
             return pages;
         }
 
-        public QFontData BuildFontData()
+		/// <summary>
+		/// Builds the font data
+		/// </summary>
+		/// <param name="saveName">The filename to save the font texture files too. If null, the texture files are not saved</param>
+		/// <returns>A <see cref="QFontData"/></returns>
+        public QFontData BuildFontData(string saveName = null)
         {
-            return BuildFontData(null);
-        }
-
-        public QFontData BuildFontData(string saveName)
-        {
+			// Check super sample level range
             if (_config.SuperSampleLevels <= 0 || _config.SuperSampleLevels > 8)
             {
                 throw new ArgumentOutOfRangeException("SuperSampleLevels = [" + _config.SuperSampleLevels + "] is an unsupported value. Please use values in the range [1,8]"); 
@@ -480,23 +516,31 @@ namespace QuickFont
             var initialBitmapData = initialBmp.LockBits(new Rectangle(0, 0, initialBmp.Width, initialBmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
 
             int minYOffset = int.MaxValue;
+
+			// Retarget each glyph rectangle to get minimum bounding box
             foreach (var glyph in initialGlyphs)
             {
                 RetargetGlyphRectangleInwards(initialBitmapData, glyph, true, _config.KerningConfig.AlphaEmptyPixelTolerance);
-                minYOffset = Math.Min(minYOffset,glyph.yOffset);
+                minYOffset = Math.Min(minYOffset,glyph.YOffset);
             }
             minYOffset--; //give one pixel of breathing room?
 
+			// Update glyph y offsets
             foreach (var glyph in initialGlyphs)
-                glyph.yOffset -= minYOffset;
+                glyph.YOffset -= minYOffset;
 
+			// Find the optimal page size for the font
             Size pagesize = GetOptimalPageSize(initialBmp.Width * _config.SuperSampleLevels, initialBmp.Height * _config.SuperSampleLevels, _config.PageMaxTextureSize);
             QFontGlyph[] glyphs;
-            List<QBitmap> bitmapPages = GenerateBitmapSheetsAndRepack(initialGlyphs, new BitmapData[1] { initialBitmapData }, pagesize.Width, pagesize.Height, out glyphs, glyphMargin);
 
+			// Generate the final bitmap pages
+            List<QBitmap> bitmapPages = GenerateBitmapSheetsAndRepack(initialGlyphs, new[] { initialBitmapData }, pagesize.Width, pagesize.Height, out glyphs, glyphMargin);
+
+			// Clean up
             initialBmp.UnlockBits(initialBitmapData);
             initialBmp.Dispose();
 
+			// Scale and retarget glyphs if needed
             if (_config.SuperSampleLevels != 1)
             {
                 ScaleSheetsAndGlyphs(bitmapPages, glyphs, 1.0f / _config.SuperSampleLevels);
@@ -506,42 +550,49 @@ namespace QuickFont
             //create list of texture pages
             var pages = new List<TexturePage>();
             foreach (var page in bitmapPages)
-                pages.Add(new TexturePage(page.bitmapData));
+                pages.Add(new TexturePage(page.BitmapData));
 
-            var fontData = new QFontData();
-            fontData.CharSetMapping = CreateCharGlyphMapping(glyphs);
-            fontData.Pages = pages.ToArray();
-            fontData.CalculateMeanWidth();
+
+			// Build the QFontData
+			var fontData = new QFontData
+			{
+				CharSetMapping = CreateCharGlyphMapping(glyphs),
+				Pages = pages.ToArray()
+			};
+			fontData.CalculateMeanWidth();
             fontData.CalculateMaxHeight();
             fontData.KerningPairs = KerningCalculator.CalculateKerning(_charSet.ToCharArray(), glyphs, bitmapPages,_config.KerningConfig, _font);
-            fontData.naturallyMonospaced = IsMonospaced(sizes);
+            fontData.NaturallyMonospaced = IsMonospaced(sizes);
 
+			// Save the font texture files if required
             if (saveName != null)
             {
                 if (bitmapPages.Count == 1)
                 {
-                    bitmapPages[0].bitmap.UnlockBits(bitmapPages[0].bitmapData);
-                    bitmapPages[0].bitmap.Save(saveName + ".png", ImageFormat.Png);
-                    bitmapPages[0] = new QBitmap(bitmapPages[0].bitmap);
+                    bitmapPages[0].Bitmap.UnlockBits(bitmapPages[0].BitmapData);
+                    bitmapPages[0].Bitmap.Save(saveName + ".png", ImageFormat.Png);
+                    bitmapPages[0] = new QBitmap(bitmapPages[0].Bitmap);
                 }
                 else
                 {
                     for (int i = 0; i < bitmapPages.Count; i++)
                     {
-                        bitmapPages[i].bitmap.UnlockBits(bitmapPages[i].bitmapData);
-                        bitmapPages[i].bitmap.Save(saveName + "_sheet_" + i + ".png", ImageFormat.Png);
-                        bitmapPages[i] = new QBitmap(bitmapPages[i].bitmap);
+                        bitmapPages[i].Bitmap.UnlockBits(bitmapPages[i].BitmapData);
+                        bitmapPages[i].Bitmap.Save(saveName + "_sheet_" + i + ".png", ImageFormat.Png);
+                        bitmapPages[i] = new QBitmap(bitmapPages[i].Bitmap);
                     }
                 }
             }
 
+			// Build the font drop shadow if required
             if (_config.ShadowConfig != null)
-                fontData.dropShadowFont = BuildDropShadow(bitmapPages, glyphs, _config.ShadowConfig, _charSet.ToCharArray(),_config.KerningConfig.AlphaEmptyPixelTolerance);
+                fontData.DropShadowFont = BuildDropShadow(bitmapPages, glyphs, _config.ShadowConfig, _charSet.ToCharArray(),_config.KerningConfig.AlphaEmptyPixelTolerance);
 
+			// Clean up resources
             foreach (var page in bitmapPages)
                 page.Free();
 
-            //validate glyphs
+			// Check that no glyphs are overlapping
             var intercept = FirstIntercept(fontData.CharSetMapping);
             if (intercept != null)
                 throw new Exception("Failed to create glyph set. Glyphs '" + intercept[0] + "' and '" + intercept[1] + "' were overlapping. This is could be due to an error in the font, or a bug in Graphics.MeasureString().");
@@ -549,24 +600,40 @@ namespace QuickFont
             return fontData;
         }
 
-        private Size GetOptimalPageSize(int width, int height, int pageMaxTextureSize)
+		/// <summary>
+		/// Returns the optimal page size
+		/// </summary>
+		/// <param name="width">The desired page width</param>
+		/// <param name="height">The desired page height</param>
+		/// <param name="pageMaxTextureSize">The max page texture size</param>
+		/// <returns>The optimal page size</returns>
+        private static Size GetOptimalPageSize(int width, int height, int pageMaxTextureSize)
         {
             int rows = (width/(pageMaxTextureSize))+1;
             return new Size(pageMaxTextureSize, rows*height);
         }
 
+		/// <summary>
+		/// Builds the drop shadow
+		/// </summary>
+		/// <param name="sourceFontSheets">The bitmap sheets from the source font</param>
+		/// <param name="sourceFontGlyphs">The glyphs from the source font</param>
+		/// <param name="shadowConfig">The shadow configuration</param>
+		/// <param name="charSet">The char set to include in the shadow</param>
+		/// <param name="alphaTolerance">The alpha tolerance</param>
+		/// <returns>The shadow QFont</returns>
         private static QFont BuildDropShadow(List<QBitmap> sourceFontSheets, QFontGlyph[] sourceFontGlyphs, QFontShadowConfiguration shadowConfig, char[] charSet, byte alphaTolerance)
         {
             QFontGlyph[] newGlyphs;
 
             var sourceBitmapData = new List<BitmapData>();
             foreach(var sourceSheet in sourceFontSheets)
-                sourceBitmapData.Add(sourceSheet.bitmapData);
+                sourceBitmapData.Add(sourceSheet.BitmapData);
             
             var bitmapSheets = GenerateBitmapSheetsAndRepack(sourceFontGlyphs, sourceBitmapData.ToArray(), shadowConfig.PageMaxTextureSize, shadowConfig.PageMaxTextureSize, out newGlyphs, shadowConfig.GlyphMargin + shadowConfig.BlurRadius*3);
 
             //scale up in case we wanted bigger/smaller shadows
-            if (shadowConfig.Scale != 1.0f)
+            if (Math.Abs(shadowConfig.Scale - 1.0f) > float.Epsilon)
                 ScaleSheetsAndGlyphs(bitmapSheets, newGlyphs, shadowConfig.Scale); //no point in retargeting yet, since we will do it after blur
 
             //whiten and blur
@@ -585,11 +652,11 @@ namespace QuickFont
             //create list of texture pages
             var newTextureSheets = new List<TexturePage>();
             foreach (var page in bitmapSheets)
-                newTextureSheets.Add(new TexturePage(page.bitmapData));
+                newTextureSheets.Add(new TexturePage(page.BitmapData));
 
-            var fontData = new QFontData();
-            fontData.CharSetMapping = new Dictionary<char, QFontGlyph>();
-            for(int i = 0; i < charSet.Length; i++)
+			var fontData = new QFontData {CharSetMapping = new Dictionary<char, QFontGlyph>()};
+
+			for(int i = 0; i < charSet.Length; i++)
                 fontData.CharSetMapping.Add(charSet[i],newGlyphs[i]);
 
             fontData.Pages = newTextureSheets.ToArray();
@@ -599,31 +666,52 @@ namespace QuickFont
             foreach (var sheet in bitmapSheets)
                 sheet.Free();
 
-            fontData.isDropShadow = true;
+            fontData.IsDropShadow = true;
             return new QFont(fontData);
         }
 
+		/// <summary>
+		/// Scales the sheets and glyphs of a font by the specified amount
+		/// </summary>
+		/// <param name="pages">The pages to scale</param>
+		/// <param name="glyphs">The glyphs to scale</param>
+		/// <param name="scale">The amount to scale by</param>
         private static void ScaleSheetsAndGlyphs(List<QBitmap> pages, QFontGlyph[] glyphs, float scale)
         {
             foreach (var page in pages)
-                page.DownScale32((int)(page.bitmap.Width * scale), (int)(page.bitmap.Height * scale));
+                page.DownScale32((int)(page.Bitmap.Width * scale), (int)(page.Bitmap.Height * scale));
 
             foreach (var glyph in glyphs)
             {
-                glyph.rect = new Rectangle((int)(glyph.rect.X * scale), (int)(glyph.rect.Y * scale), (int)(glyph.rect.Width * scale), (int)(glyph.rect.Height * scale));
-                glyph.yOffset = (int)(glyph.yOffset * scale);
+                glyph.Rect = new Rectangle((int)(glyph.Rect.X * scale), (int)(glyph.Rect.Y * scale), (int)(glyph.Rect.Width * scale), (int)(glyph.Rect.Height * scale));
+                glyph.YOffset = (int)(glyph.YOffset * scale);
             }
         }
 
+		/// <summary>
+		/// Updates the glyph targeting - required after they have been scaled
+		/// </summary>
+		/// <param name="pages">The pages containing the glyphs</param>
+		/// <param name="glyphs">The glyphs to retarget</param>
+		/// <param name="alphaTolerance">The alpha tolerance</param>
         private static void RetargetAllGlyphs(List<QBitmap> pages, QFontGlyph[] glyphs, byte alphaTolerance)
         {
             foreach (var glyph in glyphs)
-                RetargetGlyphRectangleOutwards(pages[glyph.page].bitmapData, glyph, false, alphaTolerance);
+                RetargetGlyphRectangleOutwards(pages[glyph.Page].BitmapData, glyph, false, alphaTolerance);
         }
 
+		/// <summary>
+		/// Saves the <see cref="QFontData"/> to the specified file
+		/// This is used for loading custom texture fonts
+		/// </summary>
+		/// <param name="data">The <see cref="QFontData"/> to save</param>
+		/// <param name="filePath">The filepath</param>
         public static void SaveQFontDataToFile(QFontData data, string filePath)
         {
+			// Serialize the font data
             var lines = data.Serialize();
+
+			// Write it to the file
             StreamWriter writer = new StreamWriter(filePath + ".qfont");
             foreach (var line in lines)
                 writer.WriteLine(line);
@@ -631,20 +719,34 @@ namespace QuickFont
             writer.Close();
         }
 
+		/// <summary>
+		/// Creates an individual bitmap for each glyph
+		/// </summary>
+		/// <param name="sourceGlyphs">The source glyphs</param>
+		/// <param name="sourceBitmaps">The source bitmaps</param>
+		/// <param name="destGlyphs">The destination glyphs</param>
+		/// <param name="destBitmaps">The destination bitmaps</param>
         public static void CreateBitmapPerGlyph(QFontGlyph[] sourceGlyphs, QBitmap[] sourceBitmaps, out QFontGlyph[]  destGlyphs, out QBitmap[] destBitmaps){
             destBitmaps = new QBitmap[sourceGlyphs.Length];
             destGlyphs = new QFontGlyph[sourceGlyphs.Length];
             for(int i = 0; i < sourceGlyphs.Length; i++){
                 var sg = sourceGlyphs[i];
-                destGlyphs[i] = new QFontGlyph(i,new Rectangle(0,0,sg.rect.Width,sg.rect.Height),sg.yOffset,sg.character);
-                destBitmaps[i] = new QBitmap(new Bitmap(sg.rect.Width,sg.rect.Height,PixelFormat.Format32bppArgb));
-                QBitmap.Blit(sourceBitmaps[sg.page].bitmapData,destBitmaps[i].bitmapData,sg.rect,0,0);
+                destGlyphs[i] = new QFontGlyph(i,new Rectangle(0,0,sg.Rect.Width,sg.Rect.Height),sg.YOffset,sg.Character);
+                destBitmaps[i] = new QBitmap(new Bitmap(sg.Rect.Width,sg.Rect.Height,PixelFormat.Format32bppArgb));
+                QBitmap.Blit(sourceBitmaps[sg.Page].BitmapData,destBitmaps[i].BitmapData,sg.Rect,0,0);
             }
         }
 
+		/// <summary>
+		/// Loads a <see cref="QFontData"/> from the font data file
+		/// </summary>
+		/// <param name="filePath">The font data file to load from</param>
+		/// <param name="downSampleFactor">Whether to downsample the font</param>
+		/// <param name="loaderConfig">The font loader configuration</param>
+		/// <returns>The loaded <see cref="QFontData"/></returns>
         public static QFontData LoadQFontDataFromFile(string filePath, float downSampleFactor, QFontConfiguration loaderConfig)
         {
-            var lines = new List<String>();
+            var lines = new List<string>();
             StreamReader reader = new StreamReader(filePath);
             string line;
             while((line = reader.ReadLine()) != null)
@@ -652,7 +754,7 @@ namespace QuickFont
             reader.Close();
 
             var data = new QFontData();
-            int pageCount = 0;
+            int pageCount;
             char[] charSet;
             data.Deserialize(lines, out pageCount, out charSet);
 
@@ -671,7 +773,7 @@ namespace QuickFont
             }
 
             foreach (var glyph in data.CharSetMapping.Values)
-                RetargetGlyphRectangleOutwards(bitmapPages[glyph.page].bitmapData, glyph, false, loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
+                RetargetGlyphRectangleOutwards(bitmapPages[glyph.Page].BitmapData, glyph, false, loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
  
             var intercept = FirstIntercept(data.CharSetMapping);
             if (intercept != null)
@@ -682,16 +784,16 @@ namespace QuickFont
             if (downSampleFactor > 1.0f)
             {
                 foreach (var page in bitmapPages)
-                    page.DownScale32((int)(page.bitmap.Width * downSampleFactor), (int)(page.bitmap.Height * downSampleFactor));
+                    page.DownScale32((int)(page.Bitmap.Width * downSampleFactor), (int)(page.Bitmap.Height * downSampleFactor));
 
                 foreach (var glyph in data.CharSetMapping.Values)
                 {
 
-                    glyph.rect = new Rectangle((int)(glyph.rect.X * downSampleFactor),
-                                                (int)(glyph.rect.Y * downSampleFactor),
-                                                (int)(glyph.rect.Width * downSampleFactor),
-                                                (int)(glyph.rect.Height * downSampleFactor));
-                    glyph.yOffset = (int)(glyph.yOffset * downSampleFactor);
+                    glyph.Rect = new Rectangle((int)(glyph.Rect.X * downSampleFactor),
+                                                (int)(glyph.Rect.Y * downSampleFactor),
+                                                (int)(glyph.Rect.Width * downSampleFactor),
+                                                (int)(glyph.Rect.Height * downSampleFactor));
+                    glyph.YOffset = (int)(glyph.YOffset * downSampleFactor);
                 }
             }
             else if (downSampleFactor < 1.0f )
@@ -706,19 +808,19 @@ namespace QuickFont
                 for (int i = 0; i < shrunkGlyphs.Length; i++)
                 {   
                     var bmp = shrunkBitmapsPerGlyph[i];
-                    bmp.DownScale32(Math.Max((int)(bmp.bitmap.Width * downSampleFactor),1), Math.Max((int)(bmp.bitmap.Height * downSampleFactor),1));
-                    shrunkGlyphs[i].rect = new Rectangle(0, 0, bmp.bitmap.Width, bmp.bitmap.Height);
-                    shrunkGlyphs[i].yOffset = (int)(shrunkGlyphs[i].yOffset * downSampleFactor);
+                    bmp.DownScale32(Math.Max((int)(bmp.Bitmap.Width * downSampleFactor),1), Math.Max((int)(bmp.Bitmap.Height * downSampleFactor),1));
+                    shrunkGlyphs[i].Rect = new Rectangle(0, 0, bmp.Bitmap.Width, bmp.Bitmap.Height);
+                    shrunkGlyphs[i].YOffset = (int)(shrunkGlyphs[i].YOffset * downSampleFactor);
                 }
 
                 var shrunkBitmapData = new BitmapData[shrunkBitmapsPerGlyph.Length];
                 for(int i = 0; i < shrunkBitmapsPerGlyph.Length; i ++ ){
-                    shrunkBitmapData[i] = shrunkBitmapsPerGlyph[i].bitmapData;
+                    shrunkBitmapData[i] = shrunkBitmapsPerGlyph[i].BitmapData;
                 }
 
                 //use roughly the same number of pages as before..
-                int newWidth = (int)(bitmapPages[0].bitmap.Width * (0.1f + downSampleFactor));
-                int newHeight = (int)(bitmapPages[0].bitmap.Height * (0.1f + downSampleFactor));
+                int newWidth = (int)(bitmapPages[0].Bitmap.Width * (0.1f + downSampleFactor));
+                int newHeight = (int)(bitmapPages[0].Bitmap.Height * (0.1f + downSampleFactor));
 
                 //free old bitmap pages since we are about to chuck them away
                 for (int i = 0; i < pageCount; i++)
@@ -736,12 +838,12 @@ namespace QuickFont
 
             data.Pages = new TexturePage[pageCount];
             for(int i = 0; i < pageCount; i ++ )
-                data.Pages[i] = new TexturePage(bitmapPages[i].bitmapData);
+                data.Pages[i] = new TexturePage(bitmapPages[i].BitmapData);
 
-            if (downSampleFactor != 1.0f)
+            if (Math.Abs(downSampleFactor - 1.0f) > float.Epsilon)
             {
                 foreach (var glyph in data.CharSetMapping.Values)
-                    RetargetGlyphRectangleOutwards(bitmapPages[glyph.page].bitmapData, glyph, false, loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
+                    RetargetGlyphRectangleOutwards(bitmapPages[glyph.Page].BitmapData, glyph, false, loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
 
                 intercept = FirstIntercept(data.CharSetMapping);
                 if (intercept != null)
@@ -756,7 +858,7 @@ namespace QuickFont
                 glyphList.Add(data.CharSetMapping[c]);
 
             if (loaderConfig.ShadowConfig != null)
-                data.dropShadowFont = BuildDropShadow(bitmapPages, glyphList.ToArray(), loaderConfig.ShadowConfig, Helper.ToArray(charSet),loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
+                data.DropShadowFont = BuildDropShadow(bitmapPages, glyphList.ToArray(), loaderConfig.ShadowConfig, Helper.ToArray(charSet),loaderConfig.KerningConfig.AlphaEmptyPixelTolerance);
 
             data.KerningPairs = KerningCalculator.CalculateKerning(Helper.ToArray(charSet), glyphList.ToArray(), bitmapPages, loaderConfig.KerningConfig);
             
@@ -769,6 +871,11 @@ namespace QuickFont
             return data;
         }
 
+		/// <summary>
+		/// Find the first intercept between two glyph bounding boxes
+		/// </summary>
+		/// <param name="charSet">The character set to test</param>
+		/// <returns>The overlapping characters</returns>
         private static char[] FirstIntercept(Dictionary<char,QFontGlyph> charSet)
         {
             char[] keys = Helper.ToArray(charSet.Keys);
@@ -777,15 +884,21 @@ namespace QuickFont
             {
                 for (int j = i + 1; j < keys.Length; j++)
                 {
-                    if (charSet[keys[i]].page == charSet[keys[j]].page && RectangleIntersect(charSet[keys[i]].rect, charSet[keys[j]].rect))
+                    if (charSet[keys[i]].Page == charSet[keys[j]].Page && RectangleIntersect(charSet[keys[i]].Rect, charSet[keys[j]].Rect))
                     {
-                        return new char[2] { keys[i], keys[j] };
+                        return new[] { keys[i], keys[j] };
                     }
                 }
             }
             return null;
         }
 
+		/// <summary>
+		/// Returns true if two rectangles intersect
+		/// </summary>
+		/// <param name="r1">The first rectangle</param>
+		/// <param name="r2">The second rectangle</param>
+		/// <returns>True if the rectangles intersect</returns>
         private static bool RectangleIntersect(Rectangle r1, Rectangle r2)
         {
             return (r1.X < r2.X + r2.Width && r1.X + r1.Width > r2.X &&
@@ -795,7 +908,7 @@ namespace QuickFont
         /// <summary>
         /// Returns the power of 2 that is closest to x, but not smaller than x.
         /// </summary>
-        private static int PowerOfTwo(int x)
+        public static int PowerOfTwo(int x)
         {
             int shifts = 0;
             uint val = (uint)x;

--- a/QuickFont.Shared/Builder.cs
+++ b/QuickFont.Shared/Builder.cs
@@ -513,7 +513,7 @@ namespace QuickFont
             fontData.Pages = pages.ToArray();
             fontData.CalculateMeanWidth();
             fontData.CalculateMaxHeight();
-            fontData.KerningPairs = KerningCalculator.CalculateKerning(charSet.ToCharArray(), glyphs, bitmapPages,config.KerningConfig);
+            fontData.KerningPairs = KerningCalculator.CalculateKerning(charSet.ToCharArray(), glyphs, bitmapPages,config.KerningConfig, font);
             fontData.naturallyMonospaced = IsMonospaced(sizes);
 
             if (saveName != null)

--- a/QuickFont.Shared/Builder.cs
+++ b/QuickFont.Shared/Builder.cs
@@ -12,17 +12,17 @@ namespace QuickFont
     /// Class for building a Quick Font, given a Font
     /// and a configuration object.
     /// </summary>
-    class Builder
+    internal class Builder
     {
-        private string charSet;
-        private QFontBuilderConfiguration config;
-        private IFont font;
+        private string _charSet;
+        private QFontBuilderConfiguration _config;
+        private IFont _font;
 
         public Builder(IFont font, QFontBuilderConfiguration config)
         {
-            this.charSet = config.CharSet;
-            this.config = config;
-            this.font = font;
+            _charSet = config.CharSet;
+            _config = config;
+            _font = font;
             
         }
 
@@ -49,9 +49,9 @@ namespace QuickFont
             Graphics graph = Graphics.FromImage(bmp);
             List<SizeF> sizes = new List<SizeF>();
 
-            for (int i = 0; i < charSet.Length; i++)
+            for (int i = 0; i < _charSet.Length; i++)
             {
-                var charSize = font.MeasureString("" + charSet[i], graph);
+                var charSize = font.MeasureString("" + _charSet[i], graph);
                 sizes.Add(new SizeF(charSize.Width+padding, charSize.Height+padding));
             }
 
@@ -64,7 +64,7 @@ namespace QuickFont
         private SizeF GetMaxGlyphSize(List<SizeF> sizes)
         {
             SizeF maxSize = new SizeF(0f, 0f);
-            for (int i = 0; i < charSet.Length; i++)
+            for (int i = 0; i < _charSet.Length; i++)
             {
                 if (sizes[i].Width > maxSize.Width)
                     maxSize.Width = sizes[i].Width;
@@ -79,7 +79,7 @@ namespace QuickFont
         private SizeF GetMinGlyphSize(List<SizeF> sizes)
         {
             SizeF minSize = new SizeF(float.MaxValue, float.MaxValue);
-            for (int i = 0; i < charSet.Length; i++)
+            for (int i = 0; i < _charSet.Length; i++)
             {
                 if (sizes[i].Width < minSize.Width)
                     minSize.Width = sizes[i].Width;
@@ -134,10 +134,10 @@ namespace QuickFont
         //The initial bitmap is simply a long thin strip of all glyphs in a row
         private Bitmap CreateInitialBitmap(IFont font, SizeF maxSize, int initialMargin, out QFontGlyph[] glyphs, TextGenerationRenderHint renderHint)
         {
-            glyphs = new QFontGlyph[charSet.Length];
+            glyphs = new QFontGlyph[_charSet.Length];
 
             int spacing = (int)Math.Ceiling(maxSize.Width) + 2 * initialMargin;
-            Bitmap bmp = new Bitmap(spacing * charSet.Length, (int)Math.Ceiling(maxSize.Height) + 2 * initialMargin, PixelFormat.Format24bppRgb);
+            Bitmap bmp = new Bitmap(spacing * _charSet.Length, (int)Math.Ceiling(maxSize.Height) + 2 * initialMargin, PixelFormat.Format24bppRgb);
             Graphics graph = Graphics.FromImage(bmp);
 
             switch(renderHint){
@@ -164,11 +164,11 @@ namespace QuickFont
 			graph.CompositingMode = System.Drawing.Drawing2D.CompositingMode.SourceOver;
 
             int xOffset = initialMargin;
-            for (int i = 0; i < charSet.Length; i++)
+            for (int i = 0; i < _charSet.Length; i++)
             {
-				var offset = font.DrawString("" + charSet[i], graph, Brushes.White, xOffset, initialMargin, maxSize.Height);
-                var charSize = font.MeasureString("" + charSet[i], graph);
-                glyphs[i] = new QFontGlyph(0, new Rectangle(xOffset - initialMargin + offset.X, initialMargin + offset.Y, (int)charSize.Width + initialMargin * 2, (int)charSize.Height + initialMargin * 2), 0, charSet[i]);
+				var offset = font.DrawString("" + _charSet[i], graph, Brushes.White, xOffset, initialMargin);
+                var charSize = font.MeasureString("" + _charSet[i], graph);
+                glyphs[i] = new QFontGlyph(0, new Rectangle(xOffset - initialMargin + offset.X, initialMargin + offset.Y, (int)charSize.Width + initialMargin * 2, (int)charSize.Height + initialMargin * 2), 0, _charSet[i]);
                 xOffset += (int)charSize.Width + initialMargin * 2;
             }
 
@@ -447,18 +447,18 @@ namespace QuickFont
 
         public QFontData BuildFontData(string saveName)
         {
-            if (config.SuperSampleLevels <= 0 || config.SuperSampleLevels > 8)
+            if (_config.SuperSampleLevels <= 0 || _config.SuperSampleLevels > 8)
             {
-                throw new ArgumentOutOfRangeException("SuperSampleLevels = [" + config.SuperSampleLevels + "] is an unsupported value. Please use values in the range [1,8]"); 
+                throw new ArgumentOutOfRangeException("SuperSampleLevels = [" + _config.SuperSampleLevels + "] is an unsupported value. Please use values in the range [1,8]"); 
             }
 
             int margin = 3; //margin in initial bitmap (don't bother to make configurable - likely to cause confusion
-            int glyphMargin = config.GlyphMargin * config.SuperSampleLevels;
+            int glyphMargin = _config.GlyphMargin * _config.SuperSampleLevels;
 
             QFontGlyph[] initialGlyphs;
-            var sizes = GetGlyphSizes(font);
+            var sizes = GetGlyphSizes(_font);
             var maxSize = GetMaxGlyphSize(sizes);
-            var initialBmp = CreateInitialBitmap(font, maxSize, margin, out initialGlyphs,config.TextGenerationRenderHint);
+            var initialBmp = CreateInitialBitmap(_font, maxSize, margin, out initialGlyphs,_config.TextGenerationRenderHint);
 
 #if DEBUG
 			// print bitmap with bounds to debug it
@@ -482,7 +482,7 @@ namespace QuickFont
             int minYOffset = int.MaxValue;
             foreach (var glyph in initialGlyphs)
             {
-                RetargetGlyphRectangleInwards(initialBitmapData, glyph, true, config.KerningConfig.AlphaEmptyPixelTolerance);
+                RetargetGlyphRectangleInwards(initialBitmapData, glyph, true, _config.KerningConfig.AlphaEmptyPixelTolerance);
                 minYOffset = Math.Min(minYOffset,glyph.yOffset);
             }
             minYOffset--; //give one pixel of breathing room?
@@ -490,17 +490,17 @@ namespace QuickFont
             foreach (var glyph in initialGlyphs)
                 glyph.yOffset -= minYOffset;
 
-            Size pagesize = GetOptimalPageSize(initialBmp.Width * config.SuperSampleLevels, initialBmp.Height * config.SuperSampleLevels, config.PageMaxTextureSize);
+            Size pagesize = GetOptimalPageSize(initialBmp.Width * _config.SuperSampleLevels, initialBmp.Height * _config.SuperSampleLevels, _config.PageMaxTextureSize);
             QFontGlyph[] glyphs;
             List<QBitmap> bitmapPages = GenerateBitmapSheetsAndRepack(initialGlyphs, new BitmapData[1] { initialBitmapData }, pagesize.Width, pagesize.Height, out glyphs, glyphMargin);
 
             initialBmp.UnlockBits(initialBitmapData);
             initialBmp.Dispose();
 
-            if (config.SuperSampleLevels != 1)
+            if (_config.SuperSampleLevels != 1)
             {
-                ScaleSheetsAndGlyphs(bitmapPages, glyphs, 1.0f / config.SuperSampleLevels);
-                RetargetAllGlyphs(bitmapPages, glyphs,config.KerningConfig.AlphaEmptyPixelTolerance);
+                ScaleSheetsAndGlyphs(bitmapPages, glyphs, 1.0f / _config.SuperSampleLevels);
+                RetargetAllGlyphs(bitmapPages, glyphs,_config.KerningConfig.AlphaEmptyPixelTolerance);
             }
 
             //create list of texture pages
@@ -513,7 +513,7 @@ namespace QuickFont
             fontData.Pages = pages.ToArray();
             fontData.CalculateMeanWidth();
             fontData.CalculateMaxHeight();
-            fontData.KerningPairs = KerningCalculator.CalculateKerning(charSet.ToCharArray(), glyphs, bitmapPages,config.KerningConfig, font);
+            fontData.KerningPairs = KerningCalculator.CalculateKerning(_charSet.ToCharArray(), glyphs, bitmapPages,_config.KerningConfig, _font);
             fontData.naturallyMonospaced = IsMonospaced(sizes);
 
             if (saveName != null)
@@ -535,8 +535,8 @@ namespace QuickFont
                 }
             }
 
-            if (config.ShadowConfig != null)
-                fontData.dropShadowFont = BuildDropShadow(bitmapPages, glyphs, config.ShadowConfig, charSet.ToCharArray(),config.KerningConfig.AlphaEmptyPixelTolerance);
+            if (_config.ShadowConfig != null)
+                fontData.dropShadowFont = BuildDropShadow(bitmapPages, glyphs, _config.ShadowConfig, _charSet.ToCharArray(),_config.KerningConfig.AlphaEmptyPixelTolerance);
 
             foreach (var page in bitmapPages)
                 page.Free();

--- a/QuickFont.Shared/Builder.cs
+++ b/QuickFont.Shared/Builder.cs
@@ -504,13 +504,13 @@ namespace QuickFont
 
 			foreach (var g in initialGlyphs)
 			{
-				graphics.DrawRectangle(pen, g.rect);
+				graphics.DrawRectangle(pen, g.Rect);
 			}
 
 			graphics.Flush();
 			graphics.Dispose();
 
-			debugBmp.Save(font.ToString() + "-DEBUG.png", ImageFormat.Png);
+			debugBmp.Save(_font + "-DEBUG.png", ImageFormat.Png);
 #endif
 
             var initialBitmapData = initialBmp.LockBits(new Rectangle(0, 0, initialBmp.Width, initialBmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);

--- a/QuickFont.Shared/Configuration/QFontBuilderConfiguration.cs
+++ b/QuickFont.Shared/Configuration/QFontBuilderConfiguration.cs
@@ -5,6 +5,10 @@ using System.Linq;
 
 namespace QuickFont.Configuration
 {
+	/// <summary>
+	/// Specifies the quality of rendering for fonts
+	/// Only affects GDIFonts
+	/// </summary>
     public enum TextGenerationRenderHint
     {
         /// <summary>
@@ -29,6 +33,9 @@ namespace QuickFont.Configuration
         SystemDefault
     }
 
+	/// <summary>
+	/// Flags which represent a character set for a language
+	/// </summary>
     [Flags]
     public enum CharacterSet
     {
@@ -135,21 +142,21 @@ namespace QuickFont.Configuration
     /// </summary>
     public class QFontBuilderConfiguration : QFontConfiguration
     {
-        public const string BasicSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.:,;'\"(!?)+-*/=_{}[]@~#\\<>|^%$£&€°µ";
-        public const string FrenchQuotes = "«»‹›";
-        public const string SpanishQestEx = "¡¿";
-        public const string CyrillicSet = "АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяљњќћџЉЊЌЋЏ";
-        public const string ExtendedLatin = "ÀŠŽŸžÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ";
-        public const string GreekAlphabet = "ΈΉΊΌΎΏΐΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩΪΫάέήίΰαβγδεζηθικλμνξοπρςστυφχψωϊϋόύώ";
-        public const string TurkishI = "ıİŞ";
-        public const string HebrewAlphabet = "אבגדהוזחטיכךלמםנןסעפףצץקרשת";
-        public const string ArabicAlphabet = "ںکگپچژڈ¯؛ہءآأؤإئابةتثجحخدذرزسشصض×طظعغـفقكàلâمنهوçèéêëىيîï؟";
-        public const string ThaiKhmerAlphabet = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำิีึืฺุู฿เแโใไๅๆ็่้๊๋์ํ๎๏๐๑๒๓๔๕๖๗๘๙๚๛";
-        public const string Hiragana = "ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔゕゖ゗゘゙゛゜ゝゞゟ";
-        public const string JapDigits = "㆐㆑㆒㆓㆔㆕㆖㆗㆘㆙㆚㆛㆜㆝㆞㆟";
-        public const string AsianQuotes = "「」";
-        public const string EssentialKanji = "⽇⽉";
-        public const string Katakana = "゠ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴヵヶヷヸヹヺ・ーヽヾヿ";
+	    private const string BASIC_SET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.:,;'\"(!?)+-*/=_{}[]@~#\\<>|^%$£&€°µ";
+	    private const string FRENCH_QUOTES = "«»‹›";
+	    private const string SPANISH_QEST_EX = "¡¿";
+	    private const string CYRILLIC_SET = "АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяљњќћџЉЊЌЋЏ";
+	    private const string EXTENDED_LATIN = "ÀŠŽŸžÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ";
+	    private const string GREEK_ALPHABET = "ΈΉΊΌΎΏΐΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩΪΫάέήίΰαβγδεζηθικλμνξοπρςστυφχψωϊϋόύώ";
+	    private const string TURKISH_I = "ıİŞ";
+	    private const string HEBREW_ALPHABET = "אבגדהוזחטיכךלמםנןסעפףצץקרשת";
+	    private const string ARABIC_ALPHABET = "ںکگپچژڈ¯؛ہءآأؤإئابةتثجحخدذرزسشصض×طظعغـفقكàلâمنهوçèéêëىيîï؟";
+	    private const string THAI_KHMER_ALPHABET = "กขฃคฅฆงจฉชซฌญฎฏฐฑฒณดตถทธนบปผฝพฟภมยรฤลฦวศษสหฬอฮฯะัาำิีึืฺุู฿เแโใไๅๆ็่้๊๋์ํ๎๏๐๑๒๓๔๕๖๗๘๙๚๛";
+	    private const string HIRAGANA = "ぁあぃいぅうぇえぉおかがきぎくぐけげこごさざしじすずせぜそぞただちぢっつづてでとどなにぬねのはばぱひびぴふぶぷへべぺほぼぽまみむめもゃやゅゆょよらりるれろゎわゐゑをんゔゕゖ゗゘゙゛゜ゝゞゟ";
+	    private const string JAP_DIGITS = "㆐㆑㆒㆓㆔㆕㆖㆗㆘㆙㆚㆛㆜㆝㆞㆟";
+	    private const string ASIAN_QUOTES = "「」";
+	    private const string ESSENTIAL_KANJI = "⽇⽉";
+	    private const string KATAKANA = "゠ァアィイゥウェエォオカガキギクグケゲコゴサザシジスズセゼソゾタダチヂッツヅテデトドナニヌネノハバパヒビピフブプヘベペホボポマミムメモャヤュユョヨラリルレロヮワヰヱヲンヴヵヶヷヸヹヺ・ーヽヾヿ";
 
         /// <summary>
         /// Whether to use super sampling when building font texture pages
@@ -174,17 +181,20 @@ namespace QuickFont.Configuration
         /// <summary>
         /// Set of characters to support
         /// </summary>
-        public string charSet = BuildCharacterSet(FigureOutBestCharacterSet());
+        public string CharSet = BuildCharacterSet(FigureOutBestCharacterSet());
 
         private CharacterSet _characters = CharacterSet.BasicSet;
 
+		/// <summary>
+		/// The character set for this builder configuration
+		/// </summary>
         public CharacterSet Characters
         {
             get { return _characters; }
             set
             {
                 _characters = value;
-                charSet = BuildCharacterSet(_characters);
+                CharSet = BuildCharacterSet(_characters);
             }
         }
 
@@ -193,79 +203,89 @@ namespace QuickFont.Configuration
         /// </summary>
         public TextGenerationRenderHint TextGenerationRenderHint = TextGenerationRenderHint.SizeDependent;
 
+		/// <summary>
+		/// Creates a default configuration
+		/// </summary>
         public QFontBuilderConfiguration() { }
 
-        public QFontBuilderConfiguration(bool addDropShadow, bool TransformToOrthogProjection = false) 
-            : base(addDropShadow, TransformToOrthogProjection)
+		/// <summary>
+		/// Creates a new <see cref="QFontBuilderConfiguration"/>
+		/// </summary>
+		/// <param name="addDropShadow">True to add drop shadow to the font</param>
+		/// <param name="transformToOrthogProjection">OBSOLETE</param>
+        public QFontBuilderConfiguration(bool addDropShadow, bool transformToOrthogProjection = false) 
+            : base(addDropShadow, transformToOrthogProjection)
         {
         }
 
+		/// <summary>
+		/// Creates a new <see cref="QFontBuilderConfiguration"/>
+		/// </summary>
+		/// <param name="fontConfiguration">The existing font configuration to use as a base</param>
         public QFontBuilderConfiguration(QFontConfiguration fontConfiguration)
         {
-            this.ShadowConfig = fontConfiguration.ShadowConfig;
-            this.KerningConfig = fontConfiguration.KerningConfig;
-            this.TransformToCurrentOrthogProjection = fontConfiguration.TransformToCurrentOrthogProjection;
+            ShadowConfig = fontConfiguration.ShadowConfig;
+            KerningConfig = fontConfiguration.KerningConfig;
+            TransformToCurrentOrthogProjection = fontConfiguration.TransformToCurrentOrthogProjection;
         }
 
         private static string BuildCharacterSet(CharacterSet set)
         {
             var characterSetValues = Enum.GetValues(typeof(CharacterSet));
-            string result = "";
+            var result = "";
             foreach (CharacterSet value in characterSetValues)
             {
-                if (set.HasFlag(value))
-                {
-                    switch (value)
-                    {
-                        case CharacterSet.BasicSet:
-                            result += BasicSet;
-                            break;
-                        case CharacterSet.FrenchQuotes:
-                            result += FrenchQuotes;
-                            break;
-                        case CharacterSet.SpanishQuestEx:
-                            result += SpanishQestEx;
-                            break;
-                        case CharacterSet.CyrillicSet:
-                            result += CyrillicSet;
-                            break;
-                        case CharacterSet.ExtendedLatin:
-                            result += ExtendedLatin;
-                            break;
-                        case CharacterSet.GreekAlphabet:
-                            result += GreekAlphabet;
-                            break;
-                        case CharacterSet.TurkishI:
-                            result += TurkishI;
-                            break;
-                        case CharacterSet.HebrewAlphabet:
-                            result += HebrewAlphabet;
-                            break;
-                        case CharacterSet.ArabicAlphabet:
-                            result += ArabicAlphabet;
-                            break;
-                        case CharacterSet.ThaiKhmerAlphabet:
-                            result += ThaiKhmerAlphabet;
-                            break;
-                        case CharacterSet.Hiragana:
-                            result += Hiragana;
-                            break;
-                        case CharacterSet.JapDigits:
-                            result += JapDigits;
-                            break;
-                        case CharacterSet.AsianQuotes:
-                            result += AsianQuotes;
-                            break;
-                        case CharacterSet.EssentialKanji:
-                            result += EssentialKanji;
-                            break;
-                        case CharacterSet.Katakana:
-                            result += Katakana;
-                            break;
-                    }
-                }
+	            if (!set.HasFlag(value)) continue;
+	            switch (value)
+	            {
+		            case CharacterSet.BasicSet:
+			            result += BASIC_SET;
+			            break;
+		            case CharacterSet.FrenchQuotes:
+			            result += FRENCH_QUOTES;
+			            break;
+		            case CharacterSet.SpanishQuestEx:
+			            result += SPANISH_QEST_EX;
+			            break;
+		            case CharacterSet.CyrillicSet:
+			            result += CYRILLIC_SET;
+			            break;
+		            case CharacterSet.ExtendedLatin:
+			            result += EXTENDED_LATIN;
+			            break;
+		            case CharacterSet.GreekAlphabet:
+			            result += GREEK_ALPHABET;
+			            break;
+		            case CharacterSet.TurkishI:
+			            result += TURKISH_I;
+			            break;
+		            case CharacterSet.HebrewAlphabet:
+			            result += HEBREW_ALPHABET;
+			            break;
+		            case CharacterSet.ArabicAlphabet:
+			            result += ARABIC_ALPHABET;
+			            break;
+		            case CharacterSet.ThaiKhmerAlphabet:
+			            result += THAI_KHMER_ALPHABET;
+			            break;
+		            case CharacterSet.Hiragana:
+			            result += HIRAGANA;
+			            break;
+		            case CharacterSet.JapDigits:
+			            result += JAP_DIGITS;
+			            break;
+		            case CharacterSet.AsianQuotes:
+			            result += ASIAN_QUOTES;
+			            break;
+		            case CharacterSet.EssentialKanji:
+			            result += ESSENTIAL_KANJI;
+			            break;
+		            case CharacterSet.Katakana:
+			            result += KATAKANA;
+			            break;
+	            }
             }
-            var hset = new HashSet<char>();
+	        var hset = new HashSet<char>();
             foreach (var c in result)
             {
                 hset.Add(c);
@@ -283,10 +303,10 @@ namespace QuickFont.Configuration
         /// Kerning infos (which are n² size if n is number of characters).
         /// </summary>
         /// <returns></returns>
-        static CharacterSet FigureOutBestCharacterSet()
+        private static CharacterSet FigureOutBestCharacterSet()
         {
             // he : 1255, de/en=1252, arab =ANSICodePage = 1256, bg/ru=1251, ko=949, ja =932, cz=1250, thai =847
-            TextInfo textInfo = CultureInfo.CurrentCulture.TextInfo;
+            var textInfo = CultureInfo.CurrentCulture.TextInfo;
             switch (textInfo.ANSICodePage)
             {
                 case 1251: //stands for cyrillic writing systems like bu, ru, uk

--- a/QuickFont.Shared/Configuration/QFontBuilderConfiguration.cs
+++ b/QuickFont.Shared/Configuration/QFontBuilderConfiguration.cs
@@ -309,7 +309,6 @@ namespace QuickFont.Configuration
                 case 874: // stands for thai
                     // Note this is not really supported since thai has zero space combindig characters that are not supported (or are they?)
                     return CharacterSet.Thai;
-                // TODO : add hindi, malayalam and telugu
             }
             return CharacterSet.BasicSet;
         }

--- a/QuickFont.Shared/Configuration/QFontConfiguration.cs
+++ b/QuickFont.Shared/Configuration/QFontConfiguration.cs
@@ -1,8 +1,18 @@
 ﻿namespace QuickFont.Configuration
 {
+	/// <summary>
+	/// Class to hold font configuration data
+	/// </summary>
     public class QFontConfiguration
     {
+		/// <summary>
+		/// The shadow configuration
+		/// </summary>
         public QFontShadowConfiguration ShadowConfig;
+
+		/// <summary>
+		/// The kerning configuration
+		/// </summary>
         public QFontKerningConfiguration KerningConfig = new QFontKerningConfiguration();
 
         /// <summary>
@@ -10,14 +20,22 @@
         /// </summary>
         public bool TransformToCurrentOrthogProjection;
 
+		/// <summary>
+		/// Creates a new instance of <see cref="QFontConfiguration"/>
+		/// </summary>
         public QFontConfiguration() { }
 
+		/// <summary>
+		/// Creates a new instance of <see cref="QFontConfiguration"/>
+		/// </summary>
+		/// <param name="addDropShadow">True to add a drop shadow to the font</param>
+		/// <param name="transformToOrthogProjection">OBSOLETE</param>
         public QFontConfiguration(bool addDropShadow, bool transformToOrthogProjection = false)
         {
             if (addDropShadow)
-                this.ShadowConfig = new QFontShadowConfiguration();
+				ShadowConfig = new QFontShadowConfiguration();
 
-            this.TransformToCurrentOrthogProjection = transformToOrthogProjection;
+            TransformToCurrentOrthogProjection = transformToOrthogProjection;
         }
     }
 }

--- a/QuickFont.Shared/Configuration/QFontKerningConfiguration.cs
+++ b/QuickFont.Shared/Configuration/QFontKerningConfiguration.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace QuickFont.Configuration
 {
+    /// <summary>
+    /// Kerning Rules
+    /// </summary>
     public enum CharacterKerningRule
     {
         /// <summary>
@@ -22,19 +25,24 @@ namespace QuickFont.Configuration
         NotMoreThanHalf
     }
 
+    /// <summary>
+    /// Font kerning configuration
+    /// Only used with GDIFont, FreeTypeFont uses it's own kerning directly from
+    /// the font file
+    /// </summary>
     public class QFontKerningConfiguration
     {
         /// <summary>
         /// Kerning rules for particular characters
         /// </summary>
-        private Dictionary<char, CharacterKerningRule> CharacterKerningRules = new Dictionary<char, CharacterKerningRule>();
+        private readonly Dictionary<char, CharacterKerningRule> _characterKerningRules = new Dictionary<char, CharacterKerningRule>();
 
         /// <summary>
         /// When measuring the bounds of glyphs, and performing kerning calculations, 
         /// this is the minimum alpha level that is necessray for a pixel to be considered
         /// non-empty. This should be set to a value on the range [0,255]
         /// </summary>
-        public byte alphaEmptyPixelTolerance = 0;
+        public byte AlphaEmptyPixelTolerance = 0;
 
 
         /// <summary>
@@ -46,7 +54,7 @@ namespace QuickFont.Configuration
         {
             foreach (var c in chars)
             {
-                CharacterKerningRules[c] = rule;
+                _characterKerningRules[c] = rule;
             }
         }
 
@@ -57,14 +65,19 @@ namespace QuickFont.Configuration
         /// <param name="rule"></param>
         public void SetCharacterKerningRule(char c, CharacterKerningRule rule)
         {
-            CharacterKerningRules[c] = rule;
+            _characterKerningRules[c] = rule;
         }
 
+		/// <summary>
+		/// Returns the kerning rule corresponding to the character.
+		/// </summary>
+		/// <param name="c">The character to return the kerning rule for</param>
+		/// <returns>The kerning rule corresponding to the given character</returns>
         public CharacterKerningRule GetCharacterKerningRule(char c)
         {
-            if (CharacterKerningRules.ContainsKey(c))
+            if (_characterKerningRules.ContainsKey(c))
             {
-                return CharacterKerningRules[c];
+                return _characterKerningRules[c];
             }
             return CharacterKerningRule.Normal;
         }
@@ -97,6 +110,9 @@ namespace QuickFont.Configuration
             return CharacterKerningRule.Normal;
         }
 
+		/// <summary>
+		/// Default kerning constructor
+		/// </summary>
         public QFontKerningConfiguration()
         {
             BatchSetCharacterKerningRule("_^", CharacterKerningRule.Zero);

--- a/QuickFont.Shared/Configuration/QFontShadowConfiguration.cs
+++ b/QuickFont.Shared/Configuration/QFontShadowConfiguration.cs
@@ -1,8 +1,17 @@
 ﻿namespace QuickFont.Configuration
 {
+	/// <summary>
+	/// Shadow Type
+	/// </summary>
     public enum ShadowType
     {
+		/// <summary>
+		/// Blur the font to create a shadow
+		/// </summary>
         Blurred,
+		/// <summary>
+		/// Expand the font to create a shadow
+		/// </summary>
         Expanded
     }
 
@@ -26,13 +35,13 @@
         /// The blur radius. Caution: high values will greatly impact the 
         /// time it takes to build a font shadow
         /// </summary>
-        public int blurRadius = 3;
+        public int BlurRadius = 3;
 
         /// <summary>
         /// Number of blur passes. Caution: high values will greatly impact the 
         /// time it takes to build a font shadow
         /// </summary>
-        public int blurPasses = 2;
+        public int BlurPasses = 2;
 
         /// <summary>
         /// The standard max width/height of 2D texture pages this OpenGl context wants to support

--- a/QuickFont.Shared/FreeTypeFont.cs
+++ b/QuickFont.Shared/FreeTypeFont.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 using SharpFont;
 using System.Diagnostics;
-using SharpFont.TrueType;
 using System.IO;
 
 namespace QuickFont
@@ -47,7 +43,7 @@ namespace QuickFont
 		public FreeTypeFont(string fontPath, float size, FontStyle style, int superSampleLevels = 1, float scale = 1.0f)
 		{
 			// Check that the font exists
-			if (!File.Exists(fontPath)) throw new ArgumentException("The specified font path does not exist", "fontPath");
+			if (!File.Exists(fontPath)) throw new ArgumentException("The specified font path does not exist", nameof(fontPath));
 
 			StyleFlags fontStyle = StyleFlags.None;
 			switch (style)
@@ -129,13 +125,13 @@ namespace QuickFont
 		{
 			// Check we are only passed a single character
 			if (s.Length > 1)
-				throw new ArgumentOutOfRangeException("s", "Implementation currently only supports drawing individual characters");
+				throw new ArgumentOutOfRangeException(nameof(s), "Implementation currently only supports drawing individual characters");
 
 			// Check the brush is a solid colour brush
 			if (!(color is SolidBrush))
-				throw new ArgumentException("color", "Brush is required to be a SolidBrush (single, solid color)");
+				throw new ArgumentException("Brush is required to be a SolidBrush (single, solid color)", nameof(color));
 
-			var fontColor = (color as SolidBrush).Color;
+			var fontColor = ((SolidBrush) color).Color;
 
 			// Load the glyph into the face's glyph slot
 			LoadGlyph(s[0]);
@@ -184,7 +180,7 @@ namespace QuickFont
 		{
 			// Check we are only passed a single character
 			if (s.Length > 1)
-				throw new ArgumentOutOfRangeException("s", "Implementation currently only supports drawing individual characters");
+				throw new ArgumentOutOfRangeException(nameof(s), "Implementation currently only supports drawing individual characters");
 
 			// Load the glyph into the face's glyph slot
 			LoadGlyph(s[0]);
@@ -218,6 +214,11 @@ namespace QuickFont
 						_fontFace.Dispose();
 						_fontFace = null;
 					}
+				    if (_fontLibrary != null)
+				    {
+				        _fontLibrary.Dispose();
+				        _fontLibrary = null;
+				    }
 				}
 				_disposedValue = true;
 			}

--- a/QuickFont.Shared/FreeTypeFont.cs
+++ b/QuickFont.Shared/FreeTypeFont.cs
@@ -20,9 +20,15 @@ namespace QuickFont
 
 		private int _maxHorizontalBearyingY = 0;
 
+		public float Size { get { return _fontSize; } }
+
+		public bool HasKerningInformation { get { return true; } }
+
 		public FreeTypeFont(string fontPath, float size, FontStyle style, int superSampleLevels = 1, float scale = 1.0f)
 		{
-			SharpFont.
+			// Check that the font exists
+			if (!File.Exists(fontPath)) throw new ArgumentException("The specified font path does not exist", "fontPath");
+
 			StyleFlags _fontStyle = StyleFlags.None;
 			switch (style)
 			{
@@ -88,8 +94,6 @@ namespace QuickFont
 		{
 			return _fontFace.FamilyName ?? "";
 		}
-
-		public float Size { get { return _fontSize; } }
 			
 		public Point DrawString(string s, Graphics graph, Brush color, int x, int y, float height)
 		{
@@ -119,6 +123,14 @@ namespace QuickFont
 			}
 
 			return Point.Empty;
+		}
+
+		public int GetKerning(char c1, char c2)
+		{
+			var c1Index = _fontFace.GetCharIndex(c1);
+			var c2Index = _fontFace.GetCharIndex(c2);
+			var kerning = _fontFace.GetKerning(c1Index, c2Index, KerningMode.Default);
+			return kerning.X.Ceiling();
 		}
 
 		private void LoadGlyph(char c)
@@ -161,27 +173,15 @@ namespace QuickFont
 						_fontFace = null;
 					}
 				}
-
-				// TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-				// TODO: set large fields to null.
-
 				disposedValue = true;
 			}
 		}
-
-		// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-		// ~FreeTypeFont() {
-		//   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-		//   Dispose(false);
-		// }
 
 		// This code added to correctly implement the disposable pattern.
 		public void Dispose()
 		{
 			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
 			Dispose(true);
-			// TODO: uncomment the following line if the finalizer is overridden above.
-			// GC.SuppressFinalize(this);
 		}
 	}
 }

--- a/QuickFont.Shared/GDIFont.cs
+++ b/QuickFont.Shared/GDIFont.cs
@@ -15,6 +15,8 @@ namespace QuickFont
 
 		public float Size { get { return _font.Size; } }
 
+		public bool HasKerningInformation { get { return false; } }
+
 		/// <summary>
 		///     Creates a GDI+ Font from the specified font file
 		/// </summary>
@@ -50,6 +52,11 @@ namespace QuickFont
 			graph.DrawString(s, _font, color, x, y);
 
 			return Point.Empty;
+		}
+
+		public int GetKerning(char c1, char c2)
+		{
+			throw new NotImplementedException("Font kerning for GDI Fonts is not implemented. Should be calculated manually.");
 		}
 
 		public SizeF MeasureString(string s, Graphics graph)

--- a/QuickFont.Shared/GDIFont.cs
+++ b/QuickFont.Shared/GDIFont.cs
@@ -1,30 +1,39 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Text;
 using System.Linq;
-using System.Text;
 
 namespace QuickFont
 {
+	/// <summary>
+	/// An implementation of <see cref="IFont"/> that uses the GDI system to 
+	/// load fonts (aka System.Drawing). This method does not work for loading
+	/// custom fonts on Mono, and hence FreeType is required for those
+	/// </summary>
 	public class GDIFont : IFont, IDisposable
 	{
 		private Font _font;
 		private FontFamily _fontFamily;
 
+		/// <summary>
+		/// The size of the font
+		/// </summary>
 		public float Size { get { return _font.Size; } }
 
+		/// <summary>
+		/// Whether the font has kerning information available, or if it needs
+		/// to be calculated
+		/// </summary>
 		public bool HasKerningInformation { get { return false; } }
 
 		/// <summary>
 		///     Creates a GDI+ Font from the specified font file
 		/// </summary>
 		/// <param name="fontPath">The path to the font file</param>
-		/// <param name="size"></param>
-		/// <param name="style"></param>
-		/// <param name="superSampleLevels"></param>
-		/// <param name="scale"></param>
+		/// <param name="size">The size of the font</param>
+		/// <param name="style">The font style</param>
+		/// <param name="superSampleLevels">The super sample level of the font</param>
+		/// <param name="scale">The scale of the font</param>
 		public GDIFont(string fontPath, float size, FontStyle style, int superSampleLevels = 1, float scale = 1.0f)
 		{
 			try
@@ -33,7 +42,7 @@ namespace QuickFont
 				pfc.AddFontFile(fontPath);
 				_fontFamily = pfc.Families[0];
 			}
-			catch (System.IO.FileNotFoundException ex)
+			catch (System.IO.FileNotFoundException)
 			{
 				//font file could not be found, check if it exists in the installed font collection
 				var installed = new InstalledFontCollection();
@@ -47,28 +56,54 @@ namespace QuickFont
 			_font = new Font(_fontFamily, size * scale * superSampleLevels, style);
 		}
 
-		public Point DrawString(string s, Graphics graph, Brush color, int x, int y, float height)
+		/// <summary>
+		/// Draws the given string at the specified location
+		/// </summary>
+		/// <param name="s">The string to draw</param>
+		/// <param name="graph">The graphics surface to draw the string on to</param>
+		/// <param name="color">The color of the text</param>
+		/// <param name="x">The x position of the string</param>
+		/// <param name="y">The y position of the string</param>
+		/// <returns>Returns the offset of the glyph from the given x and y. Only non-zero with <see cref="FreeTypeFont"/></returns>
+		public Point DrawString(string s, Graphics graph, Brush color, int x, int y)
 		{
 			graph.DrawString(s, _font, color, x, y);
 
 			return Point.Empty;
 		}
 
+		/// <summary>
+		/// Gets the kerning between the given characters, if the font supports it
+		/// </summary>
+		/// <param name="c1">The first character of the character pair</param>
+		/// <param name="c2">The second character of the character pair</param>
+		/// <returns>The horizontal kerning offset of the character pair</returns>
 		public int GetKerning(char c1, char c2)
 		{
 			throw new NotImplementedException("Font kerning for GDI Fonts is not implemented. Should be calculated manually.");
 		}
 
+		/// <summary>
+		/// Measures the given string and returns the size
+		/// </summary>
+		/// <param name="s">The string to measure</param>
+		/// <param name="graph">The graphics surface to use for temporary purposes</param>
+		/// <returns>The size of the given string</returns>
 		public SizeF MeasureString(string s, Graphics graph)
 		{
 			return graph.MeasureString(s, _font);
 		}
 
+		/// <summary>Returns a string that represents the current object.</summary>
+		/// <returns>A string that represents the current object.</returns>
+		/// <filterpriority>2</filterpriority>
 		public override string ToString()
 		{
 		    return _font.Name;
 		}
 
+		/// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+		/// <filterpriority>2</filterpriority>
 		public void Dispose()
 		{
 			_font.Dispose();

--- a/QuickFont.Shared/GDIFont.cs
+++ b/QuickFont.Shared/GDIFont.cs
@@ -10,7 +10,7 @@ namespace QuickFont
 	/// load fonts (aka System.Drawing). This method does not work for loading
 	/// custom fonts on Mono, and hence FreeType is required for those
 	/// </summary>
-	public class GDIFont : IFont, IDisposable
+	public sealed class GDIFont : IFont
 	{
 		private Font _font;
 		private FontFamily _fontFamily;

--- a/QuickFont.Shared/Helper.cs
+++ b/QuickFont.Shared/Helper.cs
@@ -10,8 +10,17 @@ using OpenTK.Graphics.OpenGL4;
 
 namespace QuickFont
 {
-    class Helper
+    /// <summary>
+    /// A helper class containing some useful static methods
+    /// </summary>
+	internal static class Helper
     {
+		/// <summary>
+		/// Returns an array copy of <see cref="ICollection{T}"/>
+		/// </summary>
+		/// <typeparam name="T">The type of the collection item</typeparam>
+		/// <param name="collection">The collection to copy</param>
+		/// <returns>The <see cref="ICollection{T}"/> copied to an array</returns>
         public static T[] ToArray<T>(ICollection<T> collection)
         {
             T[] output = new T[collection.Count];
@@ -38,16 +47,16 @@ namespace QuickFont
         /// <summary>
         /// Ensures that multiple states are disabled
         /// </summary>
-        /// <param name="cap"></param>
+        /// <param name="caps"></param>
         /// <param name="code"></param>
         public static void SafeGLEnable(EnableCap[] caps, Action code)
         {
-            bool[] m_previouslyEnabled = new bool[caps.Length];
+            bool[] previouslyEnabled = new bool[caps.Length];
 
             for (int i = 0; i < caps.Length; i++)
             {
                 if (GL.IsEnabled(caps[i]))
-                    m_previouslyEnabled[i] = true;
+                    previouslyEnabled[i] = true;
                 else 
                     GL.Enable(caps[i]);
             }
@@ -56,16 +65,32 @@ namespace QuickFont
 
             for (int i = 0; i < caps.Length; i++)
             {
-                if (!m_previouslyEnabled[i])
+                if (!previouslyEnabled[i])
                     GL.Disable(caps[i]);
             }
         }
 
-        public static int ToRgba(Color color)
+		/// <summary>
+		/// Converts the given <see cref="Color"/> to RGBA
+		/// <para/>
+		/// Colour bytes are converted with
+		/// <c>color.A &lt;&lt; 24 | color.B &lt;&lt; 16 | color.G &lt;&lt; 8 | color.R</c>
+		/// </summary>
+		/// <param name="color">The <see cref="Color"/> to convert</param>
+		/// <returns>The 32-bit RGBA values of the colour</returns>
+		public static int ToRgba(Color color)
         {
             return color.A << 24 | color.B << 16 | color.G << 8 | color.R;
         }
 
+		/// <summary>
+		/// Converts the given <see cref="Color"/> to a <see cref="Vector4"/>,
+		/// such that XYZW = RGBA.
+		/// <para></para>
+		/// Vector values are normalized between 0.0 and 1.0
+		/// </summary>
+		/// <param name="color">The <see cref="Color"/> to convert</param>
+		/// <returns>The <see cref="Vector4"/> of the color</returns>
         public static Vector4 ToVector4(Color color)
         {
             return new Vector4{X = (float)color.R / byte.MaxValue, Y = (float)color.G / byte.MaxValue, Z = (float)color.B / byte.MaxValue, W = (float)color.A / byte.MaxValue};

--- a/QuickFont.Shared/IFont.cs
+++ b/QuickFont.Shared/IFont.cs
@@ -6,16 +6,47 @@ using System.Text;
 
 namespace QuickFont
 {
+	/// <summary>
+	/// Represents a font
+	/// </summary>
 	public interface IFont : IDisposable
 	{
+		/// <summary>
+		/// Measures the given string and returns the size
+		/// </summary>
+		/// <param name="s">The string to measure</param>
+		/// <param name="graph">The graphics surface to use for temporary purposes</param>
+		/// <returns>The size of the given string</returns>
 		SizeF MeasureString(string s, Graphics graph);
 
+		/// <summary>
+		/// The size of the font
+		/// </summary>
 		float Size { get; }
 
+		/// <summary>
+		/// Whether the font has kerning information available, or if it needs
+		/// to be calculated
+		/// </summary>
 		bool HasKerningInformation { get; }
 
-		Point DrawString(string s, Graphics graph, Brush color, int x, int y, float height);
+		/// <summary>
+		/// Draws the given string at the specified location
+		/// </summary>
+		/// <param name="s">The string to draw</param>
+		/// <param name="graph">The graphics surface to draw the string on to</param>
+		/// <param name="color">The color of the text</param>
+		/// <param name="x">The x position of the string</param>
+		/// <param name="y">The y position of the string</param>
+		/// <returns>Returns the offset of the glyph from the given x and y. Only non-zero with <see cref="FreeTypeFont"/></returns>
+		Point DrawString(string s, Graphics graph, Brush color, int x, int y);
 
+		/// <summary>
+		/// Gets the kerning between the given characters, if the font supports it
+		/// </summary>
+		/// <param name="c1">The first character of the character pair</param>
+		/// <param name="c2">The second character of the character pair</param>
+		/// <returns>The horizontal kerning offset of the character pair</returns>
 		int GetKerning(char c1, char c2);
 	}
 }

--- a/QuickFont.Shared/IFont.cs
+++ b/QuickFont.Shared/IFont.cs
@@ -12,6 +12,10 @@ namespace QuickFont
 
 		float Size { get; }
 
+		bool HasKerningInformation { get; }
+
 		Point DrawString(string s, Graphics graph, Brush color, int x, int y, float height);
+
+		int GetKerning(char c1, char c2);
 	}
 }

--- a/QuickFont.Shared/IFont.cs
+++ b/QuickFont.Shared/IFont.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
 
 namespace QuickFont
 {

--- a/QuickFont.Shared/KerningCalculator.cs
+++ b/QuickFont.Shared/KerningCalculator.cs
@@ -4,6 +4,9 @@ using QuickFont.Configuration;
 
 namespace QuickFont
 {
+    /// <summary>
+    /// Static methods for calculating kerning
+    /// </summary>
     static class KerningCalculator
     {
         private struct XLimits
@@ -12,18 +15,29 @@ namespace QuickFont
             public int Max;
         }
 
+        /// <summary>
+        /// Calculate the kerning between two glyphs
+        /// </summary>
+        /// <param name="g1">The first glyph</param>
+        /// <param name="g2">The second glyph</param>
+        /// <param name="lim1">The first glyph limits</param>
+        /// <param name="lim2">The second glyph limits</param>
+        /// <param name="config">The kerning configuration to use</param>
+        /// <param name="font">The glyph's <see cref="IFont"/></param>
+        /// <returns>The x coordinate kerning offset</returns>
         private static int Kerning(QFontGlyph g1, QFontGlyph g2, XLimits[] lim1, XLimits[] lim2, QFontKerningConfiguration config, IFont font)
         {
 			// Use kerning information from the font if it exists
-			if (font != null && font.HasKerningInformation) return font.GetKerning(g1.character, g2.character);
+			if (font != null && font.HasKerningInformation) return font.GetKerning(g1.Character, g2.Character);
 
-            int yOffset1 = g1.yOffset;
-            int yOffset2 = g2.yOffset;
+            // Otherwise, calculate our own kerning
+            int yOffset1 = g1.YOffset;
+            int yOffset2 = g2.YOffset;
 
             int startY = Math.Max(yOffset1, yOffset2);
-            int endY = Math.Min(g1.rect.Height + yOffset1, g2.rect.Height + yOffset2);
+            int endY = Math.Min(g1.Rect.Height + yOffset1, g2.Rect.Height + yOffset2);
 
-            int w1 = g1.rect.Width;
+            int w1 = g1.Rect.Width;
 
             int worstCase = w1;
 
@@ -32,34 +46,43 @@ namespace QuickFont
             for (int j = startY; j < endY; j++)
                 worstCase = Math.Min(worstCase, w1 - lim1[j-yOffset1].Max + lim2[j-yOffset2].Min);
 
-            worstCase = Math.Min(worstCase, g1.rect.Width);
-            worstCase = Math.Min(worstCase, g2.rect.Width);
+            worstCase = Math.Min(worstCase, g1.Rect.Width);
+            worstCase = Math.Min(worstCase, g2.Rect.Width);
 
             //modify by character kerning rules
-            CharacterKerningRule kerningRule = config.GetOverridingCharacterKerningRuleForPair(""+g1.character + g2.character);
-            if (kerningRule == CharacterKerningRule.Zero)
+            CharacterKerningRule kerningRule = config.GetOverridingCharacterKerningRuleForPair(""+g1.Character + g2.Character);
+
+            switch (kerningRule)
             {
-                return 1;
-            }
-            else if (kerningRule == CharacterKerningRule.NotMoreThanHalf)
-            {
-                return 1 - (int)Math.Min(Math.Min(g1.rect.Width,g2.rect.Width)*0.5f, worstCase);
+                case CharacterKerningRule.Zero:
+                    return 1;
+                case CharacterKerningRule.NotMoreThanHalf:
+                    return 1 - (int)Math.Min(Math.Min(g1.Rect.Width,g2.Rect.Width)*0.5f, worstCase);
             }
 
             return 1 - worstCase;
         }
 
-        public static Dictionary<String, int> CalculateKerning(char[] charSet, QFontGlyph[] glyphs, List<QBitmap> bitmapPages, QFontKerningConfiguration config, IFont font = null)
+        /// <summary>
+        /// Calculates the kerning values for the given character set
+        /// </summary>
+        /// <param name="charSet">The character set to calculate kerning values for</param>
+        /// <param name="glyphs">The glyphs used for kerning</param>
+        /// <param name="bitmapPages">The bitmap pages of the glyphs</param>
+        /// <param name="config">The kerning configuration</param>
+        /// <param name="font">The <see cref="IFont"/> used to create the glyphs and bitmaps</param>
+        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> mapping of every glyph pair to a kerning amount</returns>
+        public static Dictionary<string, int> CalculateKerning(char[] charSet, QFontGlyph[] glyphs, List<QBitmap> bitmapPages, QFontKerningConfiguration config, IFont font = null)
         {
-            var kerningPairs = new Dictionary<String, int>();
+            var kerningPairs = new Dictionary<string, int>();
 
             //we start by computing the index of the first and last non-empty pixel in each row of each glyph
             XLimits[][] limits = new XLimits[charSet.Length][];
             int maxHeight = 0;
             for (int n = 0; n < charSet.Length; n++)
             {
-                var rect = glyphs[n].rect;
-                var page = bitmapPages[glyphs[n].page];
+                var rect = glyphs[n].Rect;
+                var page = bitmapPages[glyphs[n].Page];
 
                 limits[n] = new XLimits[rect.Height+1];
 
@@ -77,7 +100,7 @@ namespace QuickFont
                     bool yetToFindFirst = true;
                     for (int i = xStart; i <= xEnd; i++)
                     {
-                        if (!QBitmap.EmptyAlphaPixel(page.bitmapData, i, j,config.AlphaEmptyPixelTolerance))
+                        if (!QBitmap.EmptyAlphaPixel(page.BitmapData, i, j,config.AlphaEmptyPixelTolerance))
                         {
 
                             if (yetToFindFirst)
@@ -124,6 +147,8 @@ namespace QuickFont
                     limits[n][j] = tmp[j];
             }
 
+            // For each character in the character set, 
+            // combine it with every other character and add it to the kerning pair dictionary
             for (int i = 0; i < charSet.Length; i++)
                 for (int j = 0; j < charSet.Length; j++)
                     kerningPairs.Add("" + charSet[i] + charSet[j], Kerning(glyphs[i], glyphs[j], limits[i], limits[j],config, font));

--- a/QuickFont.Shared/KerningCalculator.cs
+++ b/QuickFont.Shared/KerningCalculator.cs
@@ -58,7 +58,7 @@ namespace QuickFont
                 var rect = glyphs[n].rect;
                 var page = bitmapPages[glyphs[n].page];
 
-                limits[n] = new XLimits[rect.Height];
+                limits[n] = new XLimits[rect.Height+1];
 
                 maxHeight = Math.Max(rect.Height, maxHeight);
 
@@ -67,12 +67,12 @@ namespace QuickFont
                 int xStart = rect.X;
                 int xEnd = rect.X + rect.Width;
 
-                for (int j = yStart; j < yEnd; j++)
+                for (int j = yStart; j <= yEnd; j++)
                 {
                     int last = xStart;
 
                     bool yetToFindFirst = true;
-                    for (int i = xStart; i < xEnd; i++)
+                    for (int i = xStart; i <= xEnd; i++)
                     {
                         if (!QBitmap.EmptyAlphaPixel(page.bitmapData, i, j,config.alphaEmptyPixelTolerance))
                         {
@@ -94,7 +94,7 @@ namespace QuickFont
             }
 
             //we now bring up each row to the max (or min) of it's two adjacent rows, this is to stop glyphs sliding together too closely
-            var tmp = new XLimits[maxHeight];
+            var tmp = new XLimits[maxHeight+1];
 
             for (int n = 0; n < charSet.Length; n++)
             {

--- a/QuickFont.Shared/KerningCalculator.cs
+++ b/QuickFont.Shared/KerningCalculator.cs
@@ -12,8 +12,11 @@ namespace QuickFont
             public int Max;
         }
 
-        private static int Kerning(QFontGlyph g1, QFontGlyph g2, XLimits[] lim1, XLimits[] lim2, QFontKerningConfiguration config)
+        private static int Kerning(QFontGlyph g1, QFontGlyph g2, XLimits[] lim1, XLimits[] lim2, QFontKerningConfiguration config, IFont font)
         {
+			// Use kerning information from the font if it exists
+			if (font != null && font.HasKerningInformation) return font.GetKerning(g1.character, g2.character);
+
             int yOffset1 = g1.yOffset;
             int yOffset2 = g2.yOffset;
 
@@ -36,17 +39,17 @@ namespace QuickFont
             CharacterKerningRule kerningRule = config.GetOverridingCharacterKerningRuleForPair(""+g1.character + g2.character);
             if (kerningRule == CharacterKerningRule.Zero)
             {
-                return 0;
+                return 1;
             }
             else if (kerningRule == CharacterKerningRule.NotMoreThanHalf)
             {
-                return (int)Math.Min(Math.Min(g1.rect.Width,g2.rect.Width)*0.5f, worstCase);
+                return 1 - (int)Math.Min(Math.Min(g1.rect.Width,g2.rect.Width)*0.5f, worstCase);
             }
 
-            return worstCase;
+            return 1 - worstCase;
         }
 
-        public static Dictionary<String, int> CalculateKerning(char[] charSet, QFontGlyph[] glyphs, List<QBitmap> bitmapPages, QFontKerningConfiguration config)
+        public static Dictionary<String, int> CalculateKerning(char[] charSet, QFontGlyph[] glyphs, List<QBitmap> bitmapPages, QFontKerningConfiguration config, IFont font = null)
         {
             var kerningPairs = new Dictionary<String, int>();
 
@@ -123,7 +126,7 @@ namespace QuickFont
 
             for (int i = 0; i < charSet.Length; i++)
                 for (int j = 0; j < charSet.Length; j++)
-                    kerningPairs.Add("" + charSet[i] + charSet[j], 1-Kerning(glyphs[i], glyphs[j], limits[i], limits[j],config));
+                    kerningPairs.Add("" + charSet[i] + charSet[j], Kerning(glyphs[i], glyphs[j], limits[i], limits[j],config, font));
 
             return kerningPairs;
         }

--- a/QuickFont.Shared/KerningCalculator.cs
+++ b/QuickFont.Shared/KerningCalculator.cs
@@ -77,7 +77,7 @@ namespace QuickFont
                     bool yetToFindFirst = true;
                     for (int i = xStart; i <= xEnd; i++)
                     {
-                        if (!QBitmap.EmptyAlphaPixel(page.bitmapData, i, j,config.alphaEmptyPixelTolerance))
+                        if (!QBitmap.EmptyAlphaPixel(page.bitmapData, i, j,config.AlphaEmptyPixelTolerance))
                         {
 
                             if (yetToFindFirst)

--- a/QuickFont.Shared/QBitmap.cs
+++ b/QuickFont.Shared/QBitmap.cs
@@ -4,36 +4,70 @@ using System.Drawing.Imaging;
 
 namespace QuickFont
 {
+    /// <summary>
+    /// The <see cref="QBitmap"/> class. Used for font bitmaps
+    /// </summary>
     public class QBitmap
     {
-        public Bitmap bitmap;
-        public BitmapData bitmapData;
+        /// <summary>
+        /// The <see cref="QBitmap"/>'s Bitmap
+        /// </summary>
+        public Bitmap Bitmap;
 
+        /// <summary>
+        /// The <see cref="QBitmap"/>'s BitmapData
+        /// </summary>
+        public BitmapData BitmapData;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="QBitmap"/> class from the 
+        /// given file path
+        /// </summary>
+        /// <param name="filePath">The file to load the bitmap from</param>
         public QBitmap(string filePath)
         {
             LockBits(new Bitmap(filePath));
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="QBitmap"/> class from an 
+        /// existing bitmap
+        /// </summary>
+        /// <param name="bitmap">The existing bitmap to use</param>
         public QBitmap(Bitmap bitmap)
         {
             LockBits(bitmap);
         }
 
+        /// <summary>
+        /// Lock the bitmap bits
+        /// </summary>
+        /// <param name="bitmap">The bitmap to lock</param>
         private void LockBits(Bitmap bitmap)
         {
-            this.bitmap = bitmap;
-            bitmapData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadWrite, bitmap.PixelFormat);
+            // Save a reference to the bitmap
+            Bitmap = bitmap;
+
+            // Lock the bitmap bits
+            BitmapData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), ImageLockMode.ReadWrite, bitmap.PixelFormat);
         }
 
+        /// <summary>
+        /// Clear the bitmap to the specified RGBA values
+        /// </summary>
+        /// <param name="r">The red value</param>
+        /// <param name="g">The green value</param>
+        /// <param name="b">The blue value</param>
+        /// <param name="a">The alpha value</param>
         public void Clear32(byte r, byte g, byte b, byte a)
         {
             unsafe
             {
-                byte* sourcePtr = (byte*) (bitmapData.Scan0);
+                byte* sourcePtr = (byte*) (BitmapData.Scan0);
 
-                for (int i = 0; i < bitmapData.Height; i++)
+                for (int i = 0; i < BitmapData.Height; i++)
                 {
-                    for (int j = 0; j < bitmapData.Width; j++)
+                    for (int j = 0; j < BitmapData.Width; j++)
                     {
                         *(sourcePtr) = b;
                         *(sourcePtr + 1) = g;
@@ -42,7 +76,7 @@ namespace QuickFont
 
                         sourcePtr += 4;
                     }
-                    sourcePtr += bitmapData.Stride - bitmapData.Width*4; //move to the end of the line (past unused space)
+                    sourcePtr += BitmapData.Stride - BitmapData.Width*4; //move to the end of the line (past unused space)
                 }
             }
         }
@@ -50,9 +84,12 @@ namespace QuickFont
         /// <summary>
         /// Returns true if the given pixel is empty (i.e. black)
         /// </summary>
+        /// <param name="bitmapData">The bitmap data</param>
+        /// <param name="px">The pixel x coordinate</param>
+        /// <param name="py">The pixel y coordinate</param>
         public static unsafe bool EmptyPixel(BitmapData bitmapData, int px, int py)
         {
-			if (px < 0 || py < 0 || px >= bitmapData.Width || py >= bitmapData.Height) return true;
+            if (px < 0 || py < 0 || px >= bitmapData.Width || py >= bitmapData.Height) return true;
             byte* addr = (byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*3;
             return (*addr == 0 && *(addr + 1) == 0 && *(addr + 2) == 0);
 
@@ -61,10 +98,14 @@ namespace QuickFont
         /// <summary>
         /// Returns true if the given pixel is empty (i.e. alpha is zero)
         /// </summary>
+        /// <param name="bitmapData">The bitmap data</param>
+        /// <param name="px">The pixel x coordinate</param>
+        /// <param name="py">The pixel y coordinate</param>
+        /// <param name="alphaEmptyPixelTolerance">The pixel alpha tolerance below which to consider the pixel empty</param>
         public static unsafe bool EmptyAlphaPixel(BitmapData bitmapData, int px, int py, byte alphaEmptyPixelTolerance)
         {
-			if (px < 0 || py < 0 || px >= bitmapData.Width || py >= bitmapData.Height) return true;
-			byte* addr = (byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*4;
+            if (px < 0 || py < 0 || px >= bitmapData.Width || py >= bitmapData.Height) return true;
+            byte* addr = (byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*4;
             return (*(addr + 3) <= alphaEmptyPixelTolerance);
 
         }
@@ -73,24 +114,27 @@ namespace QuickFont
         /// Blits a block of a bitmap data from source to destination, using the luminance of the source to determine the 
         /// alpha of the target. Source must be 24-bit, target must be 32-bit.
         /// </summary>
+        /// <param name="source">The source bitmap data</param>
+        /// <param name="target">The target bitmap data</param>
+        /// <param name="srcPx">The source rectangle x coordinate</param>
+        /// <param name="srcPy">The source rectangle y coordinate</param>
+        /// <param name="srcW">The source rectangle width</param>
+        /// <param name="srcH">The source rectangle height</param>
+        /// <param name="px">The destination rectangle x coordinate</param>
+        /// <param name="py">The destination rectangle y coordinate</param>
         public static void BlitMask(BitmapData source, BitmapData target, int srcPx, int srcPy, int srcW, int srcH, int px, int py)
         {
-
             int sourceBpp = 3;
             int targetBpp = 4;
 
-            int targetStartX, targetEndX;
-            int targetStartY, targetEndY;
-            int copyW, copyH;
+            var targetStartX = Math.Max(px, 0);
+            var targetEndX = Math.Min(px + srcW, target.Width);
 
-            targetStartX = Math.Max(px, 0);
-            targetEndX = Math.Min(px + srcW, target.Width);
+            var targetStartY = Math.Max(py, 0);
+            var targetEndY = Math.Min(py + srcH, target.Height);
 
-            targetStartY = Math.Max(py, 0);
-            targetEndY = Math.Min(py + srcH, target.Height);
-
-            copyW = targetEndX - targetStartX;
-            copyH = targetEndY - targetStartY;
+            var copyW = targetEndX - targetStartX;
+            var copyH = targetEndY - targetStartY;
 
             if (copyW < 0)
             {
@@ -139,6 +183,11 @@ namespace QuickFont
         /// <summary>
         /// Blits from source to target. Both source and target must be 32-bit
         /// </summary>
+        /// <param name="source">The source bitmap data</param>
+        /// <param name="target">The destination bitmap data</param>
+        /// <param name="sourceRect">The source rectangle</param>
+        /// <param name="px">The destination rectangle x coordinate</param>
+        /// <param name="py">The desination rectangle y coordinate</param>
         public static void Blit(BitmapData source, BitmapData target, Rectangle sourceRect, int px, int py)
         {
             Blit(source, target, sourceRect.X, sourceRect.Y, sourceRect.Width, sourceRect.Height, px, py);
@@ -147,23 +196,26 @@ namespace QuickFont
         /// <summary>
         /// Blits from source to target. Both source and target must be 32-bit
         /// </summary>
+        /// <param name="source">The source bitmap data</param>
+        /// <param name="target">The target bitmap data</param>
+        /// <param name="srcPx">The source rectangle x coordinate</param>
+        /// <param name="srcPy">The source rectangle y coordinate</param>
+        /// <param name="srcW">The source rectangle width</param>
+        /// <param name="srcH">The source rectangle height</param>
+        /// <param name="destX">The destination rectangle x coordinate</param>
+        /// <param name="destY">The destination rectangle y coordinate</param>
         public static void Blit(BitmapData source, BitmapData target, int srcPx, int srcPy, int srcW, int srcH, int destX, int destY)
         {
-
             int bpp = 4;
 
-            int targetStartX, targetEndX;
-            int targetStartY, targetEndY;
-            int copyW, copyH;
+            var targetStartX = Math.Max(destX, 0);
+            var targetEndX = Math.Min(destX + srcW, target.Width);
 
-            targetStartX = Math.Max(destX, 0);
-            targetEndX = Math.Min(destX + srcW, target.Width);
+            var targetStartY = Math.Max(destY, 0);
+            var targetEndY = Math.Min(destY + srcH, target.Height);
 
-            targetStartY = Math.Max(destY, 0);
-            targetEndY = Math.Min(destY + srcH, target.Height);
-
-            copyW = targetEndX - targetStartX;
-            copyH = targetEndY - targetStartY;
+            var copyW = targetEndX - targetStartX;
+            var copyH = targetEndY - targetStartY;
 
             if (copyW < 0)
             {
@@ -200,9 +252,18 @@ namespace QuickFont
         }
 
 
+        /// <summary>
+        /// Changes the specified pixel to the given RGBA values
+        /// </summary>
+        /// <param name="px">The pixel x coordinate</param>
+        /// <param name="py">The pixel y coordinate</param>
+        /// <param name="r">The new pixel R value</param>
+        /// <param name="g">The new pixel G value</param>
+        /// <param name="b">The new pixel B value</param>
+        /// <param name="a">The new pixel A value</param>
         public unsafe void PutPixel32(int px, int py, byte r, byte g, byte b, byte a)
         {
-            byte* addr = (byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*4;
+            byte* addr = (byte*) (BitmapData.Scan0) + BitmapData.Stride*py + px*4;
 
             *addr = b;
             *(addr + 1) = g;
@@ -210,9 +271,18 @@ namespace QuickFont
             *(addr + 3) = a;
         }
 
+        /// <summary>
+        /// Returns the RGBA values of the specified pixel
+        /// </summary>
+        /// <param name="px">The pixel x coordinate</param>
+        /// <param name="py">The pixel y coordinate</param>
+        /// <param name="r">The pixel's R value</param>
+        /// <param name="g">The pixel's G value</param>
+        /// <param name="b">The pixel's B value</param>
+        /// <param name="a">The pixel's A value</param>
         public unsafe void GetPixel32(int px, int py, ref byte r, ref byte g, ref byte b, ref byte a)
         {
-            byte* addr = (byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*4;
+            byte* addr = (byte*) (BitmapData.Scan0) + BitmapData.Stride*py + px*4;
 
             b = *addr;
             g = *(addr + 1);
@@ -220,31 +290,48 @@ namespace QuickFont
             a = *(addr + 3);
         }
 
+        /// <summary>
+        /// Change the alpha value of the specified pixel
+        /// </summary>
+        /// <param name="px">The pixel x coordinate</param>
+        /// <param name="py">The pixel y coordinate</param>
+        /// <param name="a">The new pixel A value</param>
         public unsafe void PutAlpha32(int px, int py, byte a)
         {
-            *((byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*4 + 3) = a;
+            *((byte*) (BitmapData.Scan0) + BitmapData.Stride*py + px*4 + 3) = a;
         }
 
+        /// <summary>
+        /// Return the alpha value of the specified pixel
+        /// </summary>
+        /// <param name="px">The pixel x coordinate</param>
+        /// <param name="py">The pixel y coordinate</param>
+        /// <param name="a">The pixel's A value</param>
         public unsafe void GetAlpha32(int px, int py, ref byte a)
         {
-            a = *((byte*) (bitmapData.Scan0) + bitmapData.Stride*py + px*4 + 3);
+            a = *((byte*) (BitmapData.Scan0) + BitmapData.Stride*py + px*4 + 3);
         }
 
+        /// <summary>
+        /// Downscale the 32-bit <see cref="Bitmap"/> of this <see cref="QBitmap"/> to the specified width and height
+        /// </summary>
+        /// <param name="newWidth">The new width of the bitmap</param>
+        /// <param name="newHeight">The new height of the bitmap</param>
         public void DownScale32(int newWidth, int newHeight)
         {
-            QBitmap newBitmap = new QBitmap(new Bitmap(newWidth, newHeight, bitmap.PixelFormat));
+            QBitmap newBitmap = new QBitmap(new Bitmap(newWidth, newHeight, Bitmap.PixelFormat));
 
-            if (bitmap.PixelFormat != PixelFormat.Format32bppArgb)
+            if (Bitmap.PixelFormat != PixelFormat.Format32bppArgb)
                 throw new Exception("DownsScale32 only works on 32 bit images");
 
-            float xscale = (float) bitmapData.Width/newWidth;
-            float yscale = (float) bitmapData.Height/newHeight;
+            float xscale = (float) BitmapData.Width/newWidth;
+            float yscale = (float) BitmapData.Height/newHeight;
 
             byte r = 0, g = 0, b = 0, a = 0;
-            float summedR = 0f;
-            float summedG = 0f;
-            float summedB = 0f;
-            float summedA = 0f;
+            float summedR;
+            float summedG;
+            float summedB;
+            float summedA;
 
             int left, right, top, bottom; //the area of old pixels covered by the new bitmap
 
@@ -255,7 +342,7 @@ namespace QuickFont
             float leftF, rightF, topF, bottomF; //edges of new pixel in old pixel coords
             float weight;
             float weightScale = xscale*yscale;
-            float totalColourWeight = 0f;
+            float totalColourWeight;
 
             for (int m = 0; m < newHeight; m++)
             {
@@ -276,8 +363,8 @@ namespace QuickFont
 
                     if (left < 0) left = 0;
                     if (top < 0) top = 0;
-                    if (right >= bitmapData.Width) right = bitmapData.Width - 1;
-                    if (bottom >= bitmapData.Height) bottom = bitmapData.Height - 1;
+                    if (right >= BitmapData.Width) right = BitmapData.Width - 1;
+                    if (bottom >= BitmapData.Height) bottom = BitmapData.Height - 1;
 
                     summedR = 0f;
                     summedG = 0f;
@@ -333,28 +420,28 @@ namespace QuickFont
             }
 
 
-            this.Free();
+            Free();
 
-            this.bitmap = newBitmap.bitmap;
-            this.bitmapData = newBitmap.bitmapData;
+            Bitmap = newBitmap.Bitmap;
+            BitmapData = newBitmap.BitmapData;
         }
 
         /// <summary>
-        /// Sets colour without touching alpha values
+        /// Sets colour of the <see cref="QBitmap"/> without touching alpha values
         /// </summary>
-        /// <param name="r"></param>
-        /// <param name="g"></param>
-        /// <param name="b"></param>
+        /// <param name="r">The new R value</param>
+        /// <param name="g">The new G value</param>
+        /// <param name="b">The new B value</param>
         public void Colour32(byte r, byte g, byte b)
         {
             unsafe
             {
                 byte* addr;
-                for (int i = 0; i < bitmapData.Width; i++)
+                for (int i = 0; i < BitmapData.Width; i++)
                 {
-                    for (int j = 0; j < bitmapData.Height; j++)
+                    for (int j = 0; j < BitmapData.Height; j++)
                     {
-                        addr = (byte*) (bitmapData.Scan0) + bitmapData.Stride*j + i*4;
+                        addr = (byte*) (BitmapData.Scan0) + BitmapData.Stride*j + i*4;
                         *addr = b;
                         *(addr + 1) = g;
                         *(addr + 2) = r;
@@ -363,102 +450,20 @@ namespace QuickFont
             }
         }
 
-        /*
-
-        public void Blur(int radius, int passes)
-        {
-            QBitmap tmp = new QBitmap(new Bitmap(this.bitmap.Width, this.bitmap.Height, bitmap.PixelFormat));
-
-            byte r=0,g=0,b=0,a=0;
-            int summedR, summedG, summedB, summedA;
-            int weight = 0;
-            int xpos, ypos, x, y, kx, ky;
-
-
-            for (int pass = 0; pass < passes; pass++)
-            {
-
-                //horizontal pass
-                for (y = 0; y < bitmap.Height; y++)
-                {
-                    for (x = 0; x < bitmap.Width; x++)
-                    {
-                        summedR = summedG = summedB = summedA = weight = 0;
-                        for (kx = -radius; kx <= radius; kx++)
-                        {
-                            xpos = x + kx;
-                            if (xpos >= 0 && xpos < bitmap.Width)
-                            {
-                                GetPixel32(xpos, y, ref r, ref g, ref b, ref a);
-
-
-                                summedR += r;
-                                summedG += g;
-                                summedB += b;
-                                summedA += a;
-                                weight++;
-                            }
-
-                        }
-
-                        summedR /= weight;
-                        summedG /= weight;
-                        summedB /= weight;
-                        summedA /= weight;
-
-                        tmp.PutPixel32(x, y, (byte)summedR, (byte)summedG, (byte)summedB, (byte)summedA);
-                    }
-                }
-
-
-
-                
-                //vertical pass
-                for (x = 0; x < bitmap.Width; ++x)
-                {
-                    for (y = 0; y < bitmap.Height; ++y)
-                    {
-                        summedR = summedG = summedB = summedA = weight = 0;
-                        for (ky = -radius; ky <= radius; ky++)
-                        {
-                            ypos = y + ky;
-                            if (ypos >= 0 && ypos < bitmap.Height)
-                            {
-                                tmp.GetPixel32(x, ypos, ref r, ref g, ref b, ref a);
-
-                                summedR += r;
-                                summedG += g;
-                                summedB += b;
-                                summedA += a;
-                                weight++;
-                            }
-                        }
-
-                        summedR /= weight;
-                        summedG /= weight;
-                        summedB /= weight;
-                        summedA /= weight;
-
-                        PutPixel32(x, y, (byte)summedR, (byte)summedG, (byte)summedB, (byte)summedA);
-
-                    }
-                } 
-
-            }
-
-            tmp.Free();
-
-        }*/
-
+        /// <summary>
+        /// Expand the alpha values of this <see cref="QBitmap"/>
+        /// </summary>
+        /// <param name="radius">The expansion radius</param>
+        /// <param name="passes">Number of expansion passes</param>
         public void ExpandAlpha(int radius, int passes)
         {
-            QBitmap tmp = new QBitmap(new Bitmap(this.bitmap.Width, this.bitmap.Height, bitmap.PixelFormat));
+            QBitmap tmp = new QBitmap(new Bitmap(Bitmap.Width, Bitmap.Height, Bitmap.PixelFormat));
 
             byte a = 0;
             byte max;
             int xpos, ypos, x, y, kx, ky;
-            int width = bitmap.Width;
-            int height = bitmap.Height;
+            int width = Bitmap.Width;
+            int height = Bitmap.Height;
 
             for (int pass = 0; pass < passes; pass++)
             {
@@ -511,20 +516,24 @@ namespace QuickFont
             tmp.Free();
         }
 
+        /// <summary>
+        /// Blur the alpha values of this <see cref="QBitmap"/>
+        /// </summary>
+        /// <param name="radius">The blur radius</param>
+        /// <param name="passes">The blur passes</param>
         public void BlurAlpha(int radius, int passes)
         {
-            QBitmap tmp = new QBitmap(new Bitmap(this.bitmap.Width, this.bitmap.Height, bitmap.PixelFormat));
+            QBitmap tmp = new QBitmap(new Bitmap(Bitmap.Width, Bitmap.Height, Bitmap.PixelFormat));
 
             byte a = 0;
             int summedA;
-            int weight = 0;
+            int weight;
             int xpos, ypos, x, y, kx, ky;
-            int width = bitmap.Width;
-            int height = bitmap.Height;
+            int width = Bitmap.Width;
+            int height = Bitmap.Height;
 
             for (int pass = 0; pass < passes; pass++)
             {
-
                 //horizontal pass
                 for (y = 0; y < height; y++)
                 {
@@ -546,9 +555,6 @@ namespace QuickFont
                         tmp.PutAlpha32(x, y, (byte) summedA);
                     }
                 }
-
-
-
 
                 //vertical pass
                 for (x = 0; x < width; ++x)
@@ -580,10 +586,13 @@ namespace QuickFont
 
         }
 
+        /// <summary>
+        /// Frees the resources belonging to this <see cref="QBitmap"/>
+        /// </summary>
         public void Free()
         {
-            bitmap.UnlockBits(bitmapData);
-            bitmap.Dispose();
+            Bitmap.UnlockBits(BitmapData);
+            Bitmap.Dispose();
         }
 
     }

--- a/QuickFont.Shared/QFont.cs
+++ b/QuickFont.Shared/QFont.cs
@@ -1,111 +1,95 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Drawing;
-using System.Drawing.Text;
-using System.Linq;
-using OpenTK;
 using QuickFont.Configuration;
 
 namespace QuickFont
 {
     /// <summary>
-    /// Meant to be the actual Font... a resource like <see cref="System.Drawing.Font"/>. Because it holds the textures (the fonts).
+    /// A font resource that holds the necessary data for rendering text
     /// </summary>
     [DebuggerDisplay("{FontName}")]
     public class QFont : IDisposable
     {
-        private QFontData _fontData;
         private bool _disposed;
-        private string _fontName;
 
         /// <summary>
         /// The maximum line height for the glyph set, unscaled
         /// </summary>
-        public int MaxLineHeight {get { return _fontData.maxLineHeight; }}
+        public int MaxLineHeight {get { return FontData.MaxLineHeight; }}
 
         /// <summary>
         /// The maximum glyph height for the glyph set, unscaled
         /// </summary>
-        public int MaxGlyphHeight {get { return _fontData.maxGlyphHeight; }}
+        public int MaxGlyphHeight {get { return FontData.MaxGlyphHeight; }}
+
+        /// <summary>
+        /// The <see cref="QFontData"/> corresponding to this <see cref="QFont"/>
+        /// </summary>
+        internal QFontData FontData { get; private set; }
+
+        /// <summary>
+        /// The name of this <see cref="QFont"/>
+        /// </summary>
+        public string FontName { get; }
 
         internal QFont(QFontData fontData)
         {
-            this._fontData = fontData;
+            FontData = fontData;
         }
 
         /// <summary>
-        ///     Initialise QFont from a System.Drawing.Font object
+        ///     Initialise QFont from a <see cref="IFont"/> object
         /// </summary>
-        /// <param name="font"></param>
-        /// <param name="config"></param>
+        /// <param name="font">The font object used to create this <see cref="QFont"/></param>
+        /// <param name="config">The font builder configuration</param>
         public QFont(IFont font, QFontBuilderConfiguration config = null)
         {
-            InitialiseGlFont(font, config);
+            InitialiseQFont(font, config);
         }
 
         /// <summary>
         /// Initialise QFont from a font file
         /// </summary>
         /// <param name="fontPath">The font file to load</param>
-        /// <param name="size">The size.</param>
-        /// <param name="config">The configuration.</param>
-        /// <param name="style">The style.</param>
-        /// <param name="currentProjectionMatrix">The current projection matrix to create a font pixel perfect, for.</param>
+        /// <param name="size">The size</param>
+        /// <param name="config">The configuration</param>
+        /// <param name="style">The style</param>
         public QFont(string fontPath, float size, QFontBuilderConfiguration config,
-            FontStyle style = FontStyle.Regular, Matrix4 currentProjectionMatrix = default(Matrix4))
+            FontStyle style = FontStyle.Regular)
         {
-            Viewport? transToVp = null;
             float fontScale = 1f;
-            if (config.TransformToCurrentOrthogProjection)
-                transToVp = OrthogonalTransform(out fontScale, currentProjectionMatrix);
 
-            using (IFont font = GetFont(fontPath, size, style, config == null ? 1 : config.SuperSampleLevels, fontScale))
+            using (IFont font = GetFont(fontPath, size, style, config?.SuperSampleLevels ?? 1, fontScale))
             {
-                _fontName = font.ToString();
-                InitialiseGlFont(font, config);
+                FontName = font.ToString();
+                InitialiseQFont(font, config);
             }
-
-            // TODO: What to do with transToVp?  Property:Matrix4 and use in QFontDrawing?
-            //if (transToVp != null)_fontData.Pages
-   //    Options.TransformToViewport = transToVp;
         }
 
         /// <summary>
         ///     Initialise QFont from a .qfont file
         /// </summary>
         /// <param name="qfontPath">The .qfont file to load</param>
-        /// <param name="loaderConfig"></param>
-        /// <param name="downSampleFactor"></param>
-        /// <param name="currentProjectionMatrix">The current projection matrix to create a font pixel perfect, for.</param>
-        public QFont(string qfontPath, QFontConfiguration loaderConfig, float downSampleFactor = 1.0f, Matrix4 currentProjectionMatrix = default(Matrix4))
+        /// <param name="loaderConfig">The loader configuration</param>
+        /// <param name="downSampleFactor">The downsampling factor</param>
+        public QFont(string qfontPath, QFontConfiguration loaderConfig, float downSampleFactor = 1.0f)
         {
-            Viewport? transToVp = null;
             float fontScale = 1f;
-            if (loaderConfig.TransformToCurrentOrthogProjection)
-                transToVp = OrthogonalTransform(out fontScale, currentProjectionMatrix);
 
-            InitialiseGlFont(null, new QFontBuilderConfiguration(loaderConfig), Builder.LoadQFontDataFromFile(qfontPath, downSampleFactor*fontScale, loaderConfig));
-            _fontName = qfontPath;
-            ViewportHelper.CurrentViewport.ToString();
-            // TODO: What to do with transToVp?  Property:Matrix4 and use in QFontDrawing?
-//if (transToVp != null)
-//    Options.TransformToViewport = transToVp;
+            InitialiseQFont(null, new QFontBuilderConfiguration(loaderConfig), Builder.LoadQFontDataFromFile(qfontPath, downSampleFactor*fontScale, loaderConfig));
+            FontName = qfontPath;
         }
 
-        internal QFontData FontData
+        /// <summary>
+        /// Initialises the <see cref="QFont"/> using the specified <see cref="IFont"/>
+        /// </summary>
+        /// <param name="font">The <see cref="IFont"/> to use</param>
+        /// <param name="config">The builder configuration</param>
+        /// <param name="data">The <see cref="QFontData"/> to use</param>
+        private void InitialiseQFont(IFont font, QFontBuilderConfiguration config, QFontData data = null)
         {
-            set { _fontData = value; }
-            get { return _fontData; }
-        }
-
-        public string FontName
-        {
-            get { return _fontName; }
-        }
-
-        private void InitialiseGlFont(IFont font, QFontBuilderConfiguration config, QFontData data = null)
-        {
-            _fontData = data ?? BuildFont(font, config, null);
+            FontData = data ?? BuildFont(font, config, null);
             
             // Check and fail if more than one texture was generated. The original implementation of QFont supported
             // this by choosing them as the come but this ModernOpenGl -implementation would be handycapped by 
@@ -115,7 +99,7 @@ namespace QuickFont
             // necessrily being base2 and square - this generousity should be hapily used and effiency be gained.
             // So there will be no implementation of VAO VBO based "Modern" OpenGL that is limited to 512 textures.
             // So this is a well takeable tradeoff
-            if( _fontData.Pages.Length != 1 || (_fontData.dropShadowFont != null && _fontData.dropShadowFont.FontData.Pages.Length != 1))
+            if( FontData.Pages.Length != 1 || (FontData.DropShadowFont != null && FontData.DropShadowFont.FontData.Pages.Length != 1))
             {
                 throw new NotSupportedException("The implementation of QFontDrawing does not support multiple textures per Font/Shadow. " +
                                                 "Thus this font can not be properly rendered in all cases. Reduce number of characters " +
@@ -124,30 +108,63 @@ namespace QuickFont
             }
         }
 
+        /// <summary>
+        /// Create the texture font files and save them to the specified file name
+        /// </summary>
+        /// <param name="font">The <see cref="IFont"/> object that is used to build the font</param>
+        /// <param name="newFontName">The font file name</param>
+        /// <param name="config">The builder configuration</param>
         public static void CreateTextureFontFiles(IFont font, string newFontName, QFontBuilderConfiguration config)
         {
             QFontData fontData = BuildFont(font, config, newFontName);
             Builder.SaveQFontDataToFile(fontData, newFontName);
         }
 
+        /// <summary>
+        /// Create the texture font files from the specified font file
+        /// </summary>
+        /// <param name="fileName">The font file to use to build the font</param>
+        /// <param name="size">The font size</param>
+        /// <param name="newFontName">The generated texture font file name</param>
+        /// <param name="config">The builder configuration</param>
+        /// <param name="style">The desired font style</param>
         public static void CreateTextureFontFiles(string fileName, float size, string newFontName, QFontBuilderConfiguration config, FontStyle style = FontStyle.Regular)
         {
-            using (IFont font = GetFont(fileName, size, style, config == null ? 1 : config.SuperSampleLevels))
+            using (IFont font = GetFont(fileName, size, style, config?.SuperSampleLevels ?? 1))
             {
                 CreateTextureFontFiles(font, newFontName, config);
             }
         }
 
+        /// <summary>
+        /// Returns an <see cref="IFont"/> object for the given parameters. Handles
+        /// whether font file exists in <see cref="System.Drawing.Text.InstalledFontCollection"/> or not
+        /// </summary>
+        /// <param name="fontPath">The font path or font name</param>
+        /// <param name="size">The desired font size</param>
+        /// <param name="style">The desired font style</param>
+        /// <param name="superSampleLevels">The desired supersample levels</param>
+        /// <param name="scale">The desired font scale</param>
+        /// <returns>The created <see cref="IFont"/></returns>
         private static IFont GetFont(string fontPath, float size, FontStyle style, int superSampleLevels = 1, float scale = 1.0f)
         {
             // If the font file exists load it using FreeTypeFont,
             // otherwise assume it references an internal font, and
             // load it using GDIFont (which will use the InstalledFontCollection)
             return System.IO.File.Exists(fontPath) ? 
-                (new FreeTypeFont(fontPath, size, style, superSampleLevels, scale)) as IFont : 
+                new FreeTypeFont(fontPath, size, style, superSampleLevels, scale) : 
                 (new GDIFont(fontPath, size, style, superSampleLevels, scale)) as IFont;
         }
 
+        /// <summary>
+        /// Builds the <see cref="QFontData"/> for the given <see cref="IFont"/>
+        /// </summary>
+        /// <param name="font">The <see cref="IFont"/> to use to build the <see cref="QFontData"/></param>
+        /// <param name="config">The builder configuration</param>
+        /// <param name="saveName">
+        /// The file name to save the font too. If null, the font is not saved
+        /// </param>
+        /// <returns>The build <see cref="QFontData"/></returns>
         private static QFontData BuildFont(IFont font, QFontBuilderConfiguration config, string saveName)
         {
             var builder = new Builder(font, config);
@@ -155,30 +172,18 @@ namespace QuickFont
         }
 
         /// <summary>
-        ///     When TransformToOrthogProjection is enabled, we need to get the current orthogonal transformation,
-        ///     the font scale, and ensure that the projection is actually orthogonal
+        /// Dispose the resources used by this <see cref="QFont"/> object
         /// </summary>
-        /// <param name="fontScale"></param>
-        /// <param name="viewportTransform"></param>
-        private Viewport OrthogonalTransform(out float fontScale, Matrix4 orthoProjMatrix)
-        {
-            if (!ViewportHelper.IsOrthographicProjection(ref orthoProjMatrix))
-                throw new ArgumentOutOfRangeException(
-                    "orthoProjMatrix",
-                    "Current projection matrix was not Orthogonal. Please ensure that you have set an orthogonal projection before attempting to create a font with the TransformToOrthogProjection flag set to true.");
-
-            //var viewportTransform = new Viewport(left, top, right - left, bottom - top);
-            Viewport viewportTransform = ViewportHelper.GetViewportFromOrthographicProjection(ref orthoProjMatrix);
-            fontScale = Math.Abs(ViewportHelper.CurrentViewport.Value.Height / viewportTransform.Height);
-            return viewportTransform;
-        }
-
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Dispose the resources used by this <see cref="QFont"/> object
+        /// </summary>
+        /// <param name="disposing">Whether we are actually disposing</param>
         protected virtual void Dispose(bool disposing)
         {
             // Check to see if Dispose has already been called.

--- a/QuickFont.Shared/QFontData.cs
+++ b/QuickFont.Shared/QFontData.cs
@@ -4,12 +4,15 @@ using System.Drawing;
 
 namespace QuickFont
 {
+    /// <summary>
+    /// This class holds all the necessary font data
+    /// </summary>
     class QFontData
     {
         /// <summary>
         /// Mapping from a pair of characters to a pixel offset
         /// </summary>
-        public Dictionary<String, int> KerningPairs;
+        public Dictionary<string, int> KerningPairs;
 
         /// <summary>
         /// List of texture pages
@@ -24,46 +27,60 @@ namespace QuickFont
         /// <summary>
         /// The average glyph width
         /// </summary>
-        public float meanGlyphWidth;
+        public float MeanGlyphWidth;
 
         /// <summary>
         /// The maximum glyph height
         /// </summary>
-        public int maxGlyphHeight;
+        public int MaxGlyphHeight;
 
         /// <summary>
         /// The maximum line height
         /// </summary>
-        public int maxLineHeight;
+        public int MaxLineHeight;
 
         /// <summary>
         /// Null if no dropShadowFont is available
         /// </summary>
-        public QFont dropShadowFont;
+        public QFont DropShadowFont;
 
         /// <summary>
         /// true if this font is dropShadowFont
         /// </summary>
-        public bool isDropShadow;
+        public bool IsDropShadow;
 
         /// <summary>
         /// Whether the original font (from ttf) was detected to be monospaced
         /// </summary>
-        public bool naturallyMonospaced = false;
+        public bool NaturallyMonospaced = false;
 
+        /// <summary>
+        /// Whether this font is being rendered as monospaced
+        /// </summary>
+        /// <param name="options">The render options</param>
+        /// <returns>True if the font is rendered as monospaced</returns>
         public bool IsMonospacingActive(QFontRenderOptions options)
         {
-            return (options.Monospacing == QFontMonospacing.Natural && naturallyMonospaced) || options.Monospacing == QFontMonospacing.Yes; 
+            return (options.Monospacing == QFontMonospacing.Natural && NaturallyMonospaced) || options.Monospacing == QFontMonospacing.Yes; 
         }
 
+        /// <summary>
+        /// Returns the monospace width
+        /// </summary>
+        /// <param name="options">The font rendering options</param>
+        /// <returns>The monospace width</returns>
         public float GetMonoSpaceWidth(QFontRenderOptions options)
         {
-            return (float)Math.Ceiling(1 + (1 + options.CharacterSpacing) * meanGlyphWidth);
+            return (float)Math.Ceiling(1 + (1 + options.CharacterSpacing) * MeanGlyphWidth);
         }
 
-        public List<String> Serialize()
+        /// <summary>
+        /// Serialize this <see cref="QFontData"/> to a collection of <see cref="string"/>s
+        /// </summary>
+        /// <returns>The serialized <see cref="QFontData"/></returns>
+        public List<string> Serialize()
         {
-            var data = new List<String>();
+            var data = new List<string>();
 
             data.Add("" + Pages.Length);
             data.Add("" + CharSetMapping.Count);
@@ -74,17 +91,23 @@ namespace QuickFont
                 var glyph = glyphChar.Value;
 
                 data.Add("" + chr + " " + 
-                    glyph.page + " " +
-                    glyph.rect.X + " " +
-                    glyph.rect.Y + " " +
-                    glyph.rect.Width + " " +
-                    glyph.rect.Height + " " +
-                    glyph.yOffset);
+                    glyph.Page + " " +
+                    glyph.Rect.X + " " +
+                    glyph.Rect.Y + " " +
+                    glyph.Rect.Width + " " +
+                    glyph.Rect.Height + " " +
+                    glyph.YOffset);
             }
             return data;
         }
 
-        public void Deserialize(List<String> input, out int pageCount, out char[] charSet)
+        /// <summary>
+        /// Deserialize a <see cref="QFontData"/> object, given the serialized data
+        /// </summary>
+        /// <param name="input">The serialized data</param>
+        /// <param name="pageCount">The number of texture pages</param>
+        /// <param name="charSet">The character set supported by this <see cref="QFontData"/></param>
+        public void Deserialize(List<string> input, out int pageCount, out char[] charSet)
         {
             CharSetMapping = new Dictionary<char, QFontGlyph>();
             var charSetList = new List<char>();
@@ -110,23 +133,29 @@ namespace QuickFont
             charSet = charSetList.ToArray();
         }
 
+        /// <summary>
+        /// Calculate the mean width of all glyphs in this <see cref="QFontData"/>
+        /// </summary>
         public void CalculateMeanWidth()
         {
-            meanGlyphWidth = 0f;
+            MeanGlyphWidth = 0f;
             foreach (var glyph in CharSetMapping)
-                meanGlyphWidth += glyph.Value.rect.Width;
+                MeanGlyphWidth += glyph.Value.Rect.Width;
 
-            meanGlyphWidth /= CharSetMapping.Count;
+            MeanGlyphWidth /= CharSetMapping.Count;
         }
 
+        /// <summary>
+        /// Calculate the mean height of all glyphs in this <see cref="QFontData"/>
+        /// </summary>
         public void CalculateMaxHeight()
         {
-            maxGlyphHeight = 0;
-            maxLineHeight = 0;
+            MaxGlyphHeight = 0;
+            MaxLineHeight = 0;
             foreach (var glyph in CharSetMapping)
             {
-                maxGlyphHeight = Math.Max(glyph.Value.rect.Height, maxGlyphHeight);
-                maxLineHeight = Math.Max(glyph.Value.rect.Height + glyph.Value.yOffset, maxLineHeight);
+                MaxGlyphHeight = Math.Max(glyph.Value.Rect.Height, MaxGlyphHeight);
+                MaxLineHeight = Math.Max(glyph.Value.Rect.Height + glyph.Value.YOffset, MaxLineHeight);
             }
         }
 
@@ -135,10 +164,10 @@ namespace QuickFont
         /// Also, if the text is part of a textNode list, the nextNode is given so that the following 
         /// node can be checked incase of two adjacent word nodes.
         /// </summary>
-        /// <param name="index"></param>
-        /// <param name="text"></param>
-        /// <param name="textNode"></param>
-        /// <returns></returns>
+        /// <param name="index">The character index into the string</param>
+        /// <param name="text">The string of text containing the character to kern</param>
+        /// <param name="textNode">The next text node</param>
+        /// <returns>The kerning correction for the character pair</returns>
         public int GetKerningPairCorrection(int index, string text, TextNode textNode)
         {
             if (KerningPairs == null)
@@ -160,7 +189,7 @@ namespace QuickFont
 
             chars[0] = text[index];
 
-            String str = new String(chars);
+            var str = new string(chars);
 
             if (KerningPairs.ContainsKey(str))
                 return KerningPairs[str];
@@ -168,6 +197,9 @@ namespace QuickFont
             return 0;
         }
 
+        /// <summary>
+        /// Frees all resources used by this <see cref="QFontData"/> object
+        /// </summary>
         public void Dispose()
         {
             // release all textures
@@ -175,8 +207,7 @@ namespace QuickFont
                 page.Dispose();
 
             // and also all sub-fonts if there
-            if(dropShadowFont != null)
-                dropShadowFont.Dispose();
+            DropShadowFont?.Dispose();
         }
     }
 }

--- a/QuickFont.Shared/QFontDrawing.cs
+++ b/QuickFont.Shared/QFontDrawing.cs
@@ -13,47 +13,70 @@ using OpenTK.Graphics.OpenGL4;
 namespace QuickFont
 {
     /// <summary>
-    /// This class represents a 'Drawing' on screen made off of Font renderings. eg. GlFontDrawingPrimitive
+    /// <see cref="QFontDrawing"/> manages a collection of <see cref="QFontDrawingPrimitive"/>'s
+    /// and handles printing text to the screen
     /// </summary>
     public class QFontDrawing
     {
-        //private QFontRenderOptions options = new QFontRenderOptions();
-        private const string shaderVersionString130 = "#version 130\n\n";
-        private const string shaderVersionString140 = "#version 140\n\n";
-        private const string shaderVersionString150 = "#version 150\n\n";
+        private const string SHADER_VERSION_STRING130 = "#version 130\n\n";
+        private const string SHADER_VERSION_STRING140 = "#version 140\n\n";
+        private const string SHADER_VERSION_STRING150 = "#version 150\n\n";
 
-        private static SharedState _QFontSharedState;
+        private static QFontSharedState _sharedState;
 
-        public QVertexArrayObject _vertexArrayObject;
-        private SharedState _instanceSharedState;
+        /// <summary>
+        /// The <see cref="QVertexArrayObject"/> used by this <see cref="QFontDrawing"/>
+        /// </summary>
+        public QVertexArrayObject VertexArrayObject;
+
+        private QFontSharedState _instanceSharedState;
         private readonly List<QFontDrawingPrimitive> _glFontDrawingPrimitives;
         private readonly bool _useDefaultBlendFunction;
 
         private Matrix4 _projectionMatrix;
 
-        public QFontDrawing(bool useDefaultBlendFunction = true)
+        /// <summary>
+        /// Creates a new instance of <see cref="QFontDrawing"/>
+        /// </summary>
+        /// <param name="useDefaultBlendFunction">Whether to use the default blend function</param>
+        /// <param name="state">The QFontSharedState of this object. If null, will use the static state</param>
+        public QFontDrawing(bool useDefaultBlendFunction = true, QFontSharedState state = null)
         {
             _useDefaultBlendFunction = useDefaultBlendFunction;
             _glFontDrawingPrimitives =new List<QFontDrawingPrimitive>();
-            InitialiseState();
+            InitialiseState(state);
         }
 
-        public static SharedState QFontSharedState
+        /// <summary>
+        /// The static shared state for all <see cref="QFontDrawing"/> objects
+        /// </summary>
+        public static QFontSharedState SharedState
         {
-            get { return _QFontSharedState; }
+            get { return _sharedState; }
         }
 
-        public SharedState InstanceSharedState
+        /// <summary>
+        /// Returns the instance shared state if it exists, otherwise
+        /// returns the static shared state
+        /// </summary>
+        public QFontSharedState InstanceSharedState
         {
-            get { return _instanceSharedState ?? QFontSharedState; }
+            get { return _instanceSharedState ?? SharedState; }
         }
 
+        /// <summary>
+        /// The projection matrix used for text rendering
+        /// </summary>
         public Matrix4 ProjectionMatrix
         {
             get { return _projectionMatrix; }
             set { _projectionMatrix = value; }
         }
 
+        /// <summary>
+        /// A list of <see cref="QFontDrawingPrimitive"/>'s that will be drawn
+        /// when the <see cref="Draw"/> method is called
+        /// </summary>
         public List<QFontDrawingPrimitive> DrawingPrimitives
         {
             get { return _glFontDrawingPrimitives; }
@@ -63,7 +86,7 @@ namespace QuickFont
         /// Load shader string from resource
         /// </summary>
         /// <param name="path">filename of Shader</param>
-        /// <returns></returns>
+        /// <returns>The loaded shader</returns>
         private static string LoadShaderFromResource(string path)
         {
             var assembly = Assembly.GetExecutingAssembly();
@@ -84,10 +107,11 @@ namespace QuickFont
         }
 
         /// <summary>
-        ///     Initializes the static shared render state
+        ///     Initializes the static shared render state using builtin shaders
         /// </summary>
         private static void InitialiseStaticState()
         {
+            // Enable 2D textures
             GL.Enable(EnableCap.Texture2D);
 
             //Create vertex and fragment shaders
@@ -100,7 +124,7 @@ namespace QuickFont
 
             // We try to compile the shaders with ever increasing version numbers (up to 1.50)
             // This fixes a bug on MaxOSX where the Core profile only supports shaders >= 1.50 (or sometimes 1.40)
-            var versions = new string[] { shaderVersionString130, shaderVersionString140, shaderVersionString150 };
+            var versions = new[] { SHADER_VERSION_STRING130, SHADER_VERSION_STRING140, SHADER_VERSION_STRING150 };
 
             // Holds the compilation status of the shaders
             int vertCompileStatus = 0;
@@ -108,10 +132,6 @@ namespace QuickFont
 
             foreach (var version in versions)
             {
-                // These assignments are not needed
-                vertCompileStatus = 0;
-                fragCompileStatus = 0;
-
 #if OPENGL_ES
                 GL.ShaderSource(vert, LoadShaderFromResource("simple_es.vs"));
                 GL.ShaderSource(frag, LoadShaderFromResource("simple_es.fs"));
@@ -144,9 +164,6 @@ namespace QuickFont
                 throw new Exception(String.Format("Shaders were not compiled correctly. Info logs are\nVert:\n{0}\nFrag:\n{1}", vertInfo, fragInfo));
             }
 
-            // I don't think we need to loop through versions for the linking step, as any compilation errors should be picked up
-            // in the previous loop? TODO: Verify this assumption
-
             int prog;
             int progLinkStatus;
 
@@ -178,9 +195,9 @@ namespace QuickFont
 
             //Now we have all the information, time to create the immutable shared state object
             var shaderVariables = new ShaderVariables(prog, mvpLoc, tcLoc, posLoc, samplerLoc, colLoc);
-            var sharedState = new SharedState(TextureUnit.Texture0, shaderVariables);
+            var sharedState = new QFontSharedState(TextureUnit.Texture0, shaderVariables);
 
-            _QFontSharedState = sharedState;
+            _sharedState = sharedState;
         }
 
         /// <summary>
@@ -190,31 +207,11 @@ namespace QuickFont
         ///     If state is null, this method will instead initialise the static state, which is returned when no
         ///     instance state is set
         /// </param>
-        private void InitialiseState()
+        private void InitialiseState(QFontSharedState state)
         {
-            if (QFontSharedState == null) InitialiseStaticState();
+            if (state != null) _instanceSharedState = state;
+            else if (SharedState == null) InitialiseStaticState();
         }
-
-        /// <summary>
-        ///     When TransformToOrthogProjection is enabled, we need to get the current orthogonal transformation,
-        ///     the font scale, and ensure that the projection is actually orthogonal
-        /// </summary>
-        /// <param name="fontScale"></param>
-        /// <param name="viewportTransform"></param>
-        [Obsolete]
-        private Viewport OrthogonalTransform(out float fontScale)
-        {
-            if (!ViewportHelper.IsOrthographicProjection(ref _projectionMatrix))
-                throw new ArgumentOutOfRangeException(
-                    "Current projection matrix was not Orthogonal. Please ensure that you have set an orthogonal projection before attempting to create a font with the TransformToOrthogProjection flag set to true.",
-                    "projectionMatrix");
-
-            //var viewportTransform = new Viewport(left, top, right - left, bottom - top);
-            Viewport viewportTransform = ViewportHelper.GetViewportFromOrthographicProjection(ref _projectionMatrix);
-            fontScale = Math.Abs(ViewportHelper.CurrentViewport.Value.Height/viewportTransform.Height);
-            return viewportTransform;
-        }
-
 
         /// <summary>
         /// Helper method to reduce lines of code related to simple font drawing.
@@ -234,22 +231,22 @@ namespace QuickFont
             GL.ActiveTexture(InstanceSharedState.DefaultTextureUnit);
 
             int start = 0;
-            _vertexArrayObject.Bind();
+            VertexArrayObject.Bind();
             foreach (var primitive in _glFontDrawingPrimitives)
             {
                 var dpt = PrimitiveType.Triangles;
-                GL.ActiveTexture(QFontSharedState.DefaultTextureUnit);
+                GL.ActiveTexture(SharedState.DefaultTextureUnit);
 
                 // Use DrawArrays - first draw drop shadows, then draw actual font primitive
                 if (primitive.ShadowVertexRepr.Count > 0)
                 {
                     //int index = primitive.Font.FontData.CalculateMaxHeight();
-                    GL.BindTexture(TextureTarget.Texture2D, primitive.Font.FontData.dropShadowFont.FontData.Pages[0].GLTexID);
+                    GL.BindTexture(TextureTarget.Texture2D, primitive.Font.FontData.DropShadowFont.FontData.Pages[0].TextureID);
                     GL.DrawArrays(dpt, start, primitive.ShadowVertexRepr.Count);
                     start += primitive.ShadowVertexRepr.Count;
                 }
 
-                GL.BindTexture(TextureTarget.Texture2D, primitive.Font.FontData.Pages[0].GLTexID);
+                GL.BindTexture(TextureTarget.Texture2D, primitive.Font.FontData.Pages[0].TextureID);
                 GL.DrawArrays(dpt, start, primitive.CurrentVertexRepr.Count);
                 start += primitive.CurrentVertexRepr.Count;
             }
@@ -260,10 +257,13 @@ namespace QuickFont
             GL.BindBuffer(BufferTarget.ArrayBuffer, 0);
         }
 
+        /// <summary>
+        /// Bind the 0'th shader and disable the attributes used
+        /// </summary>
         public void DisableShader()
         {
             GL.UseProgram(0);
-            _vertexArrayObject.DisableAttributes();
+            VertexArrayObject.DisableAttributes();
         }
 
         /// <summary>
@@ -283,21 +283,29 @@ namespace QuickFont
         /// </summary>
         public void RefreshBuffers()
         {
-            if (_vertexArrayObject == null)
+            if (VertexArrayObject == null)
             {
-                _vertexArrayObject = new QVertexArrayObject(QFontSharedState);
+                VertexArrayObject = new QVertexArrayObject(SharedState);
             }
 
-            _vertexArrayObject.Reset();
+            VertexArrayObject.Reset();
 
             foreach (var primitive in _glFontDrawingPrimitives)
             {
-                _vertexArrayObject.AddVertexes(primitive.ShadowVertexRepr);
-                _vertexArrayObject.AddVertexes(primitive.CurrentVertexRepr);
+                VertexArrayObject.AddVertexes(primitive.ShadowVertexRepr);
+                VertexArrayObject.AddVertexes(primitive.CurrentVertexRepr);
             }
-            _vertexArrayObject.Load();
+            VertexArrayObject.Load();
         }
 
+        /// <summary>
+        /// Prints the specified text with the given render options
+        /// </summary>
+        /// <param name="font">The <see cref="QFont"/> to print the text with</param>
+        /// <param name="text">The text to print</param>
+        /// <param name="position">The position of the text</param>
+        /// <param name="opt">The text render options</param>
+        /// <returns>The size of the printed text</returns>
         public SizeF Print(QFont font, ProcessedText text, Vector3 position, QFontRenderOptions opt)
         {
             var dp = new QFontDrawingPrimitive(font, opt);
@@ -305,16 +313,30 @@ namespace QuickFont
             return dp.Print(text, position, opt.ClippingRectangle);
         }
 
-        public SizeF Print(QFont font, ProcessedText processedText, Vector3 position, Color? colour = null, Rectangle clippingRectangle = default(Rectangle))
+        /// <summary>
+        /// Prints the specified text
+        /// </summary>
+        /// <param name="font">The <see cref="QFont"/> to print the text with</param>
+        /// <param name="processedText">The processed text to print</param>
+        /// <param name="position">The position of the text</param>
+        /// <param name="colour">The colour of the text</param>
+        /// <returns>The size of the printed text</returns>
+        public SizeF Print(QFont font, ProcessedText processedText, Vector3 position, Color? colour = null)
         {
             var dp = new QFontDrawingPrimitive(font);
             DrawingPrimitives.Add(dp);
-            if (colour.HasValue)
-                return dp.Print(processedText, position, colour.Value);
-            else
-                return dp.Print(processedText, position);
+            return colour.HasValue ? dp.Print(processedText, position, colour.Value) : dp.Print(processedText, position);
         }
 
+        /// <summary>
+        /// Prints the specified text with the given alignment and render options
+        /// </summary>
+        /// <param name="font">The <see cref="QFont"/> to print the text with</param>
+        /// <param name="text">The text to print</param>
+        /// <param name="position">The position of the text</param>
+        /// <param name="alignment">The alignment of the text</param>
+        /// <param name="opt">The render options</param>
+        /// <returns>The size of the printed text</returns>
         public SizeF Print(QFont font, string text, Vector3 position, QFontAlignment alignment, QFontRenderOptions opt)
         {
             var dp = new QFontDrawingPrimitive(font, opt);
@@ -322,6 +344,16 @@ namespace QuickFont
             return dp.Print(text, position, alignment, opt.ClippingRectangle);
         }
 
+        /// <summary>
+        /// Prints the specified text with the given alignment, color and clipping rectangle
+        /// </summary>
+        /// <param name="font">The <see cref="QFont"/> to print the text with</param>
+        /// <param name="text">The text to print</param>
+        /// <param name="position">The position of the text</param>
+        /// <param name="alignment">The alignment of the text</param>
+        /// <param name="color">The colour of the text</param>
+        /// <param name="clippingRectangle">The clipping rectangle to scissor test the text with</param>
+        /// <returns>The size of the printed text</returns>
         public SizeF Print(QFont font, string text, Vector3 position, QFontAlignment alignment, Color? color = null, Rectangle clippingRectangle = default(Rectangle))
         {
             var dp = new QFontDrawingPrimitive(font);
@@ -331,6 +363,16 @@ namespace QuickFont
             return dp.Print(text, position, alignment, clippingRectangle);
         }
 
+        /// <summary>
+        /// Prints the specified text with the given maximum size, alignment and clipping rectangle
+        /// </summary>
+        /// <param name="font">The <see cref="QFont"/> to print the text with</param>
+        /// <param name="text">The text to print</param>
+        /// <param name="position">The position of the text</param>
+        /// <param name="maxSize">The maximum bounding size of the text</param>
+        /// <param name="alignment">The text alignment</param>
+        /// <param name="clippingRectangle">The clipping rectangle to scissor test the text with</param>
+        /// <returns>The size of the printed text</returns>
         public SizeF Print(QFont font, string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, Rectangle clippingRectangle = default(Rectangle))
         {
             var dp = new QFontDrawingPrimitive(font);
@@ -338,6 +380,16 @@ namespace QuickFont
             return dp.Print(text, position, maxSize, alignment, clippingRectangle);
         }
 
+        /// <summary>
+        /// Prints the specified text with the given maximum size, alignment and render options
+        /// </summary>
+        /// <param name="font">The <see cref="QFont"/> to print the text with</param>
+        /// <param name="text">The text to print</param>
+        /// <param name="position">The position of the text</param>
+        /// <param name="maxSize">The maximum bounding size of the text</param>
+        /// <param name="alignment">The text alignment</param>
+        /// <param name="opt">The render options</param>
+        /// <returns>The size of the printed text</returns>
         public SizeF Print(QFont font, string text, Vector3 position, SizeF maxSize, QFontAlignment alignment, QFontRenderOptions opt )
         {
             var dp = new QFontDrawingPrimitive(font, opt);
@@ -345,10 +397,10 @@ namespace QuickFont
             return dp.Print(text, position, maxSize, alignment, opt.ClippingRectangle);
         }
 
-#region IDisposable impl
-
-        // Track whether Dispose has been called.
-        private bool disposed;
+        /// <summary>
+        /// Track whether <see cref="Dispose"/> has been called
+        /// </summary>
+        private bool _disposed;
 
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
@@ -372,30 +424,45 @@ namespace QuickFont
         // If disposing equals false, the method has been called by the
         // runtime from inside the finalizer and you should not reference
         // other objects. Only unmanaged resources can be disposed.
+
+        /// <summary>
+        /// Handles disposing objects
+        /// </summary>
+        /// <param name="disposing"></param>
         protected virtual void Dispose(bool disposing)
         {
             // Check to see if Dispose has already been called.
-            if (!disposed)
+            if (!_disposed)
             {
                 // If disposing equals true, dispose all managed
                 // and unmanaged resources.
                 if (disposing)
                 {
                     //QFontDrawingPrimitive.Font.FontData.Dispose();
-                    _vertexArrayObject.Dispose();
+                    VertexArrayObject.Dispose();
                 }
 
                 // Note disposing has been done.
-                disposed = true;
+                _disposed = true;
             }
         }
-
-#endregion
     }
 
 
+    /// <summary>
+    /// Holds the shader state
+    /// </summary>
     public class ShaderVariables
     {
+        /// <summary>
+        /// Create a new instance of <see cref="ShaderVariables"/>
+        /// </summary>
+        /// <param name="shaderProgram">The shader program</param>
+        /// <param name="mvpUniformLocation">The model-view-projection matrix uniform location</param>
+        /// <param name="textureCoordAttribLocation">The texture coordinate attribute location</param>
+        /// <param name="positionCoordAttribLocation">The position coordinate attribute location</param>
+        /// <param name="samplerLocation">The texture sample location</param>
+        /// <param name="colorCoordAttribLocation">The color coordinate attribute location</param>
         public ShaderVariables(int shaderProgram, int mvpUniformLocation, int textureCoordAttribLocation, int positionCoordAttribLocation, int samplerLocation, int colorCoordAttribLocation)
         {
             ColorCoordAttribLocation = colorCoordAttribLocation;
@@ -406,24 +473,63 @@ namespace QuickFont
             ShaderProgram = shaderProgram;
         }
 
-        public int ShaderProgram { get; private set; }
-        public int MVPUniformLocation { get; private set; }
+        /// <summary>
+        /// The shader program name
+        /// </summary>
+        public int ShaderProgram { get; }
+
+        /// <summary>
+        /// The Model-View-Projection matrix uniform location
+        /// </summary>
+        public int MVPUniformLocation { get; }
+
+        /// <summary>
+        /// The texture coordinate attribute location
+        /// </summary>
         public int TextureCoordAttribLocation { get; private set; }
+
+        /// <summary>
+        /// The position coordinate attribute location
+        /// </summary>
         public int PositionCoordAttribLocation { get; private set; }
-        public int SamplerLocation { get; private set; }
+
+        /// <summary>
+        /// The texture sample location
+        /// </summary>
+        public int SamplerLocation { get; }
+
+        /// <summary>
+        /// The color coordinate attribute location
+        /// </summary>
         public int ColorCoordAttribLocation { get; private set; }
     }
 
-    public class SharedState
+    /// <summary>
+    /// The shared state of the <see cref="QFontDrawing"/> object.
+    /// This can be shared between different <see cref="QFontDrawing"/> objects
+    /// </summary>
+    public class QFontSharedState
     {
-        public SharedState(TextureUnit defaultTextureUnit, ShaderVariables shaderVariables)
+        /// <summary>
+        /// Creates a new instance of <see cref="QFontSharedState"/>
+        /// </summary>
+        /// <param name="defaultTextureUnit">The default texture unit</param>
+        /// <param name="shaderVariables">The shader variables</param>
+        public QFontSharedState(TextureUnit defaultTextureUnit, ShaderVariables shaderVariables)
         {
             DefaultTextureUnit = defaultTextureUnit;
             ShaderVariables = shaderVariables;
         }
 
-        public TextureUnit DefaultTextureUnit { get; private set; }
-        public ShaderVariables ShaderVariables { get; private set; }
+        /// <summary>
+        /// The default texture unit of this shared state
+        /// </summary>
+        public TextureUnit DefaultTextureUnit { get; }
+
+        /// <summary>
+        /// The shader variables of this shared state
+        /// </summary>
+        public ShaderVariables ShaderVariables { get; }
     }
 
 }

--- a/QuickFont.Shared/QFontDrawing.cs
+++ b/QuickFont.Shared/QFontDrawing.cs
@@ -16,7 +16,7 @@ namespace QuickFont
     /// <see cref="QFontDrawing"/> manages a collection of <see cref="QFontDrawingPrimitive"/>'s
     /// and handles printing text to the screen
     /// </summary>
-    public class QFontDrawing
+    public class QFontDrawing : IDisposable
     {
         private const string SHADER_VERSION_STRING130 = "#version 130\n\n";
         private const string SHADER_VERSION_STRING140 = "#version 140\n\n";
@@ -398,7 +398,7 @@ namespace QuickFont
         }
 
         /// <summary>
-        /// Track whether <see cref="Dispose"/> has been called
+        /// Track whether <see cref="Dispose()"/> has been called
         /// </summary>
         private bool _disposed;
 
@@ -439,7 +439,11 @@ namespace QuickFont
                 if (disposing)
                 {
                     //QFontDrawingPrimitive.Font.FontData.Dispose();
-                    VertexArrayObject.Dispose();
+                    if (VertexArrayObject != null)
+                    {
+                        VertexArrayObject.Dispose();
+                        VertexArrayObject = null;
+                    }
                 }
 
                 // Note disposing has been done.

--- a/QuickFont.Shared/QFontGlyph.cs
+++ b/QuickFont.Shared/QFontGlyph.cs
@@ -3,35 +3,45 @@ using System.Drawing;
 
 namespace QuickFont
 {
-    [DebuggerDisplay("{character} Pg:{page}")]
+    /// <summary>
+    /// A <see cref="QFontGlyph"/> that holds the glyph data
+    /// </summary>
+    [DebuggerDisplay("{Character} Pg:{Page}")]
     public class QFontGlyph
     {
         /// <summary>
         /// Which texture page the glyph is on
         /// </summary>
-        public int page; 
+        public int Page; 
         
         /// <summary>
         /// The rectangle defining the glyphs position on the page
         /// </summary>
-        public Rectangle rect;
+        public Rectangle Rect;
         
         /// <summary>
         /// How far the glyph would need to be vertically offset to be vertically in line with the tallest glyph in the set of all glyphs
         /// </summary>
-        public int yOffset;
+        public int YOffset;
 
         /// <summary>
         /// Which character this glyph represents
         /// </summary>
-        public char character;
+        public char Character;
 
+        /// <summary>
+        /// Create a new <see cref="QFontGlyph"/> object
+        /// </summary>
+        /// <param name="page">The texture page this glyph is on</param>
+        /// <param name="rect">The glyph rectangle</param>
+        /// <param name="yOffset">The glyph y offset</param>
+        /// <param name="character">The glyph character</param>
         public QFontGlyph(int page, Rectangle rect, int yOffset, char character)
         {
-            this.page = page;
-            this.rect = rect;
-            this.yOffset = yOffset;
-            this.character = character;
+            Page = page;
+            Rect = rect;
+            YOffset = yOffset;
+            Character = character;
         }
     }
 }

--- a/QuickFont.Shared/QFontRenderOptions.cs
+++ b/QuickFont.Shared/QFontRenderOptions.cs
@@ -3,9 +3,56 @@ using OpenTK;
 
 namespace QuickFont
 {
-    public enum QFontAlignment { Left=0, Right, Centre, Justify }
-    public enum QFontMonospacing { Natural = 0, Yes, No }
+    /// <summary>
+    /// Text Alignment
+    /// </summary>
+    public enum QFontAlignment
+    {
+        /// <summary>
+        /// Left-aligned text
+        /// </summary>
+        Left=0,
 
+        /// <summary>
+        /// Right-aligned text
+        /// </summary>
+        Right,
+
+        /// <summary>
+        /// Centred text
+        /// </summary>
+        Centre,
+
+        /// <summary>
+        /// Justified text
+        /// </summary>
+        Justify
+    }
+
+    /// <summary>
+    /// Monospace handling
+    /// </summary>
+    public enum QFontMonospacing
+    {
+        /// <summary>
+        /// Monospace only if the font is monospaced
+        /// </summary>
+        Natural = 0,
+
+        /// <summary>
+        /// Force monospacing
+        /// </summary>
+        Yes,
+
+        /// <summary>
+        /// Don't monospace
+        /// </summary>
+        No
+    }
+
+    /// <summary>
+    /// Contains options used for font rendering
+    /// </summary>
     public class QFontRenderOptions
     {
         /// <summary>
@@ -33,7 +80,7 @@ namespace QuickFont
         /// the QFont to have been loaded with a drop shadow to
         /// take effect.
         /// </summary>
-        public bool DropShadowActive = false;
+        public bool DropShadowActive;
 
         /// <summary>
         /// Offset of the shadow from the font glyphs in units of average glyph width
@@ -45,6 +92,9 @@ namespace QuickFont
         /// </summary>
         public Color DropShadowColour = Color.FromArgb(128, Color.Black);
 
+        /// <summary>
+        /// Set the opacity of the drop shadow
+        /// </summary>
         public float DropShadowOpacity
         {
             set
@@ -113,7 +163,7 @@ namespace QuickFont
         /// 
         /// 
         /// </summary>
-        public Viewport? TransformToViewport = null;
+        public Viewport? TransformToViewport;
 
         /// <summary>
         /// Locks the position to a particular pixel, allowing the text to be rendered pixel-perfectly.
@@ -141,8 +191,6 @@ namespace QuickFont
         /// </summary>
         public bool WordWrap = true;
 
-        #region Justify Options
-
         /// <summary>
         /// When a line of text is justified, space may be inserted between
         /// characters, and between words. 
@@ -158,19 +206,14 @@ namespace QuickFont
         /// </summary>
         public float JustifyCharacterWeightForExpand
         {
-            get { return justifyCharWeightForExpand; }
+            get { return _justifyCharWeightForExpand; }
             set { 
 
-                justifyCharWeightForExpand = MathHelper.Clamp(value, 0.0f, 1.0f);
-
-                //if (justifyCharWeightForExpand < 0f)
-                //    justifyCharWeightForExpand = 0f;
-                //else if (justifyCharWeightForExpand > 1.0f)
-                //    justifyCharWeightForExpand = 1.0f;
+                _justifyCharWeightForExpand = MathHelper.Clamp(value, 0.0f, 1.0f);
             }
         }
 
-        private float justifyCharWeightForExpand = 0.5f;
+        private float _justifyCharWeightForExpand = 0.5f;
 
         /// <summary>
         /// When a line of text is justified, space may be removed between
@@ -187,20 +230,14 @@ namespace QuickFont
         /// </summary>
         public float JustifyCharacterWeightForContract
         {
-            get { return justifyCharWeightForContract; }
+            get { return _justifyCharWeightForContract; }
             set
             {
-
-                justifyCharWeightForContract = value;
-
-                if (justifyCharWeightForContract < 0f)
-                    justifyCharWeightForContract = 0f;
-                else if (justifyCharWeightForContract > 1.0f)
-                    justifyCharWeightForContract = 1.0f;
+                _justifyCharWeightForContract = MathHelper.Clamp(value, 0.0f, 1.0f);
             }
         }
 
-        private float justifyCharWeightForContract = 0.2f;
+        private float _justifyCharWeightForContract = 0.2f;
 
         /// <summary>
         /// Total justification cap as a fraction of the boundary width.
@@ -223,36 +260,40 @@ namespace QuickFont
         /// </summary>
         public float JustifyContractionPenalty = 2;
 
+        /// <summary>
+        /// The clipping rectangle to use for rendering
+        /// </summary>
         public Rectangle ClippingRectangle = default(Rectangle);
 
-        #endregion
-
+        /// <summary>
+        /// Creates a clone of the render options
+        /// </summary>
+        /// <returns>The clone of the render options</returns>
         public QFontRenderOptions CreateClone()
         {
-            var clone = new QFontRenderOptions();
-
-            clone.Colour = Colour;
-            clone.CharacterSpacing = CharacterSpacing;
-            clone.WordSpacing = WordSpacing;
-            clone.LineSpacing = LineSpacing;
-            clone.DropShadowActive = DropShadowActive;
-            clone.DropShadowOffset = DropShadowOffset;
-            clone.DropShadowColour = DropShadowColour;
-            clone.Monospacing = Monospacing;
-            clone.TransformToViewport = TransformToViewport;
-            clone.LockToPixel = LockToPixel;
-            clone.LockToPixelRatio = LockToPixelRatio;
-            clone.UseDefaultBlendFunction = UseDefaultBlendFunction;
-            clone.JustifyCharacterWeightForExpand = JustifyCharacterWeightForExpand;
-            clone.justifyCharWeightForExpand = justifyCharWeightForExpand; 
-            clone.JustifyCharacterWeightForContract = JustifyCharacterWeightForContract;
-            clone.justifyCharWeightForContract = justifyCharWeightForContract;
-            clone.JustifyCapExpand = JustifyCapExpand;
-            clone.JustifyCapContract = JustifyCapContract;
-            clone.JustifyContractionPenalty = JustifyContractionPenalty;
-            clone.ClippingRectangle = ClippingRectangle;
-
-            return clone;
+            return new QFontRenderOptions
+            {
+                Colour = Colour,
+                CharacterSpacing = CharacterSpacing,
+                WordSpacing = WordSpacing,
+                LineSpacing = LineSpacing,
+                DropShadowActive = DropShadowActive,
+                DropShadowOffset = DropShadowOffset,
+                DropShadowColour = DropShadowColour,
+                Monospacing = Monospacing,
+                TransformToViewport = TransformToViewport,
+                LockToPixel = LockToPixel,
+                LockToPixelRatio = LockToPixelRatio,
+                UseDefaultBlendFunction = UseDefaultBlendFunction,
+                JustifyCharacterWeightForExpand = JustifyCharacterWeightForExpand,
+                _justifyCharWeightForExpand = _justifyCharWeightForExpand,
+                JustifyCharacterWeightForContract = JustifyCharacterWeightForContract,
+                _justifyCharWeightForContract = _justifyCharWeightForContract,
+                JustifyCapExpand = JustifyCapExpand,
+                JustifyCapContract = JustifyCapContract,
+                JustifyContractionPenalty = JustifyContractionPenalty,
+                ClippingRectangle = ClippingRectangle
+            };
         }
     }
 }

--- a/QuickFont.Shared/QVertexArrayObject.cs
+++ b/QuickFont.Shared/QVertexArrayObject.cs
@@ -10,48 +10,74 @@ using OpenTK.Graphics.OpenGL4;
 
 namespace QuickFont
 {
+    /// <summary>
+    /// A wrapper around OpenGL's vertex array objects
+    /// </summary>
     public class QVertexArrayObject : IDisposable
     {
-        private const int InitialSize = 1000;
+        private const int INITIAL_SIZE = 1000;
+
         private int _bufferSize;
         private int _bufferMaxVertexCount;
+
+        /// <summary>
+        /// The number of vertices stored in the vertex array buffer
+        /// </summary>
         public int VertexCount;
+#if !OPENGL_ES
+        /// <summary>
+        /// The vertex array object ID
+        /// </summary>
+        private int _VAOID;
+#endif
 
-        private int VAOID;
-        private int VBOID;
+        /// <summary>
+        /// The vertex buffer object ID
+        /// </summary>
+        private int _VBOID;
 
-        public readonly SharedState QFontSharedState;
+        /// <summary>
+        /// The shared state of this <see cref="QVertexArrayObject"/>
+        /// </summary>
+        public readonly QFontSharedState QFontSharedState;
 
-        private List<QVertex> Vertices;
-        private QVertex[] VertexArray;
+        private List<QVertex> _vertices;
+        private QVertex[] _vertexArray;
 
         private static readonly int QVertexStride;
 
+        /// <summary>
+        /// Default static constructor. Initializes the <see cref="QVertexStride"/> field
+        /// </summary>
         static QVertexArrayObject()
         {
             QVertexStride = BlittableValueType.StrideOf(default(QVertex));
         }
 
-        public QVertexArrayObject(SharedState state)
+        /// <summary>
+        /// Creates a new instance of <see cref="QVertexArrayObject"/>
+        /// </summary>
+        /// <param name="state">The <see cref="QFontSharedState"/> to use</param>
+        public QVertexArrayObject(QFontSharedState state)
         {
             QFontSharedState = state;
 
-            Vertices = new List<QVertex>(InitialSize);
-            _bufferMaxVertexCount = InitialSize;
+            _vertices = new List<QVertex>(INITIAL_SIZE);
+            _bufferMaxVertexCount = INITIAL_SIZE;
             _bufferSize = _bufferMaxVertexCount * QVertexStride;
 
 #if !OPENGL_ES
-            VAOID = GL.GenVertexArray();
+            _VAOID = GL.GenVertexArray();
 #endif
 
             GL.UseProgram(QFontSharedState.ShaderVariables.ShaderProgram);
 
 #if !OPENGL_ES
-            GL.BindVertexArray(VAOID);
+            GL.BindVertexArray(_VAOID);
 #endif
 
-            GL.GenBuffers(1, out VBOID);
-            GL.BindBuffer(BufferTarget.ArrayBuffer, VBOID);
+            GL.GenBuffers(1, out _VBOID);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _VBOID);
             EnableAttributes();
 
             GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)_bufferSize, IntPtr.Zero, BufferUsageHint.StreamDraw );
@@ -63,16 +89,26 @@ namespace QuickFont
 #endif
         }
 
+        /// <summary>
+        /// Add verticies to the vertex collection
+        /// </summary>
+        /// <param name="vertices">The verticies to add</param>
         internal void AddVertexes(IList<QVertex> vertices)
         {
             VertexCount += vertices.Count;
-            Vertices.AddRange(vertices);
+            _vertices.AddRange(vertices);
         }
 
+        /// <summary>
+        /// Adds a single vertex to the vertex collection
+        /// </summary>
+        /// <param name="position">The vertex position</param>
+        /// <param name="textureCoord">The vertex texture coordinate</param>
+        /// <param name="colour">The vertex colour</param>
         public void AddVertex(Vector3 position, Vector2 textureCoord, Vector4 colour)
         {
             VertexCount++;
-            Vertices.Add(new QVertex
+            _vertices.Add(new QVertex
             {
                 Position = position,
                 TextureCoord = textureCoord,
@@ -80,57 +116,72 @@ namespace QuickFont
             });
         }
 
+        /// <summary>
+        /// Loads the current vertex collection into the VBO
+        /// </summary>
         public void Load()
         {
             if (VertexCount == 0)
                 return;
-            VertexArray = Vertices.ToArray();
-            GL.BindBuffer(BufferTarget.ArrayBuffer, VBOID);
+            _vertexArray = _vertices.ToArray();
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _VBOID);
 
 #if OPENGL_ES
             EnableAttributes();
 #else
-            GL.BindVertexArray(VAOID);
+            GL.BindVertexArray(_VAOID);
 #endif
 
             if (VertexCount > _bufferMaxVertexCount)
             {
                 while (VertexCount > _bufferMaxVertexCount)
                 {
-                    _bufferMaxVertexCount += InitialSize;
+                    _bufferMaxVertexCount += INITIAL_SIZE;
                     _bufferSize = _bufferMaxVertexCount*QVertexStride;
                 }
 
                 //reinitialise buffer with new _bufferSize
                 GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr) _bufferSize, IntPtr.Zero, BufferUsageHint.StreamDraw);
             }
-            GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, (IntPtr) (VertexCount*QVertexStride), VertexArray);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, (IntPtr) (VertexCount*QVertexStride), _vertexArray);
         }
 
+        /// <summary>
+        /// Clears the vertex collection
+        /// </summary>
         public void Reset()
         {
-            Vertices.Clear();
+            _vertices.Clear();
             VertexCount = 0;
         }
 
+        /// <summary>
+        /// Binds the vertex array object and vertex buffer object
+        /// </summary>
         public void Bind()
         {
 #if OPENGL_ES
-            GL.BindBuffer(BufferTarget.ArrayBuffer, VBOID);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, _VBOID);
             EnableAttributes();
 #else
-            GL.BindVertexArray(VAOID);
+            GL.BindVertexArray(_VAOID);
 #endif
         }
 
+        /// <summary>
+        /// Disposes resources used by <see cref="QVertexArrayObject"/>
+        /// </summary>
         public void Dispose()
         {
-            GL.DeleteBuffers(1, ref VBOID);
+            GL.DeleteBuffers(1, ref _VBOID);
 #if !OPENGL_ES
-            GL.DeleteVertexArrays(1, ref VAOID);
+            GL.DeleteVertexArrays(1, ref _VAOID);
 #endif
         }
 
+        /// <summary>
+        /// Disable the vertex attribute arrays
+        /// </summary>
         public void DisableAttributes()
         {
             GL.DisableVertexAttribArray(QFontSharedState.ShaderVariables.PositionCoordAttribLocation);
@@ -138,6 +189,9 @@ namespace QuickFont
             GL.DisableVertexAttribArray(QFontSharedState.ShaderVariables.ColorCoordAttribLocation);
         }
 
+        /// <summary>
+        /// Enable the vertex attribute arrays
+        /// </summary>
         private void EnableAttributes()
         {
             int stride = QVertexStride;
@@ -154,6 +208,9 @@ namespace QuickFont
         }
     }
 
+    /// <summary>
+    /// Vertex data structure
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct QVertex
     {

--- a/QuickFont.Shared/QVertexArrayObject.cs
+++ b/QuickFont.Shared/QVertexArrayObject.cs
@@ -168,16 +168,6 @@ namespace QuickFont
 #endif
         }
 
-        /// <summary>
-        /// Disposes resources used by <see cref="QVertexArrayObject"/>
-        /// </summary>
-        public void Dispose()
-        {
-            GL.DeleteBuffers(1, ref _VBOID);
-#if !OPENGL_ES
-            GL.DeleteVertexArrays(1, ref _VAOID);
-#endif
-        }
 
         /// <summary>
         /// Disable the vertex attribute arrays
@@ -205,6 +195,46 @@ namespace QuickFont
                 stride, new IntPtr(3*sizeof (float)));
             GL.VertexAttribPointer(QFontSharedState.ShaderVariables.ColorCoordAttribLocation, 4, VertexAttribPointerType.Float,
                 false, stride, new IntPtr(5*sizeof (float)));
+        }
+
+        private bool _disposedValue; // To detect redundant calls
+
+        /// <summary>
+        /// Disposes resources used by <see cref="QVertexArrayObject"/>
+        /// </summary>
+        /// <param name="disposing">Whether to dispose managed resources as well as unmanaged</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    GL.DeleteBuffers(1, ref _VBOID);
+#if !OPENGL_ES
+                    GL.DeleteVertexArrays(1, ref _VAOID);
+#endif
+
+                    if (_vertices != null)
+                    {
+                        _vertices.Clear();
+                        _vertices = null;
+                    }
+                }
+
+                _vertexArray = null;
+
+                _disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Disposes resources used by <see cref="QVertexArrayObject"/>
+        /// </summary>
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
         }
     }
 

--- a/QuickFont.Shared/TextNodeList.cs
+++ b/QuickFont.Shared/TextNodeList.cs
@@ -5,28 +5,83 @@ using System.Text;
 
 namespace QuickFont
 {
-    enum TextNodeType { Word, LineBreak, Space }
+    /// <summary>
+    /// The Text Node Type
+    /// </summary>
+    enum TextNodeType
+    {
+        /// <summary>
+        /// Word
+        /// </summary>
+        Word,
 
+        /// <summary>
+        /// Line Break
+        /// </summary>
+        LineBreak,
+
+        /// <summary>
+        /// Space
+        /// </summary>
+        Space
+    }
+
+    /// <summary>
+    /// A Text Node
+    /// </summary>
     class TextNode
     {
+        /// <summary>
+        /// Text node type
+        /// </summary>
         public TextNodeType Type;
+
+        /// <summary>
+        /// Text node text
+        /// </summary>
         public string Text;
-        public float Length; //pixel length (without tweaks)
-        public float LengthTweak; //length tweak for justification
+
+        /// <summary>
+        /// The length of this text node (in pixels, without tweaks)
+        /// </summary>
+        public float Length;
+
+        /// <summary>
+        /// The length tweaks of this text node (in pixels, teaks for justification)
+        /// </summary>
+        public float LengthTweak;
+
+        /// <summary>
+        /// The height of this text node
+        /// </summary>
         public float Height;
 
+        /// <summary>
+        /// The modified length of this text node
+        /// </summary>
         public float ModifiedLength
         {
             get { return Length + LengthTweak; }
         }
 
-
-        public TextNode(TextNodeType Type, string Text){
-            this.Type = Type;
-            this.Text = Text;
+        /// <summary>
+        /// Creates a new instance of <see cref="TextNode"/>
+        /// </summary>
+        /// <param name="type">The text node type</param>
+        /// <param name="text">The text node text</param>
+        public TextNode(TextNodeType type, string text){
+            Type = type;
+            Text = text;
         }
 
+        /// <summary>
+        /// The next text node
+        /// </summary>
         public TextNode Next;
+
+        /// <summary>
+        /// The previous text node
+        /// </summary>
         public TextNode Previous;
 
     }
@@ -37,9 +92,9 @@ namespace QuickFont
     /// </summary>
     public class ProcessedText
     {
-        internal TextNodeList textNodeList;
-        internal SizeF maxSize;
-        internal QFontAlignment alignment;
+        internal TextNodeList TextNodeList;
+        internal SizeF MaxSize;
+        internal QFontAlignment Alignment;
     }
 
     /// <summary>
@@ -47,7 +102,14 @@ namespace QuickFont
     /// </summary>
     class TextNodeList : IEnumerable
     {
+        /// <summary>
+        /// The head of the text node linked list
+        /// </summary>
         public TextNode Head;
+
+        /// <summary>
+        /// The tail of the text node linked list
+        /// </summary>
         public TextNode Tail;
 
         /// <summary>
@@ -63,9 +125,9 @@ namespace QuickFont
             bool wordInProgress = false;
             StringBuilder currentWord = new StringBuilder();
 
-            for (int i = 0; i < text.Length; i++)
+            foreach (char t in text)
             {
-                if (text[i] == '\r' || text[i] == '\n' || text[i] == ' ')
+                if (t == '\r' || t == '\n' || t == ' ')
                 {
                     if (wordInProgress)
                     {
@@ -73,9 +135,9 @@ namespace QuickFont
                         wordInProgress = false;
                     }
 
-                    if (text[i] == '\r' || text[i] == '\n')
+                    if (t == '\r' || t == '\n')
                         Add(new TextNode(TextNodeType.LineBreak, null));
-                    else if (text[i] == ' ')
+                    else if (t == ' ')
                         Add(new TextNode(TextNodeType.Space, null));
 
                 }
@@ -87,9 +149,8 @@ namespace QuickFont
                         currentWord = new StringBuilder();
                     }
 
-                    currentWord.Append(text[i]);
+                    currentWord.Append(t);
                 }
-
             }
 
             if (wordInProgress)
@@ -98,14 +159,26 @@ namespace QuickFont
             #endregion
         }
 
+        /// <summary>
+        /// Measures each text node using the specified font data and render options
+        /// </summary>
+        /// <param name="fontData">The font data to use for measuring</param>
+        /// <param name="options">The render options</param>
         public void MeasureNodes(QFontData fontData, QFontRenderOptions options){
             
             foreach(TextNode node in this){
-                if(node.Length == 0f)
+                if(Math.Abs(node.Length) < float.Epsilon)
                     node.Length = MeasureTextNodeLength(node,fontData,options);
             }
         }
 
+        /// <summary>
+        /// Measures the length of a text node
+        /// </summary>
+        /// <param name="node">The text node to measure</param>
+        /// <param name="fontData">The font data to use for measuring</param>
+        /// <param name="options">The render options</param>
+        /// <returns>The length of the text node</returns>
         private float MeasureTextNodeLength(TextNode node, QFontData fontData, QFontRenderOptions options)
         {
 
@@ -117,7 +190,7 @@ namespace QuickFont
                 if (monospaced)
                     return monospaceWidth;
 
-                return (float)Math.Ceiling(fontData.meanGlyphWidth * options.WordSpacing);
+                return (float)Math.Ceiling(fontData.MeanGlyphWidth * options.WordSpacing);
             }
 
             float length = 0f;
@@ -134,8 +207,8 @@ namespace QuickFont
                         if (monospaced)
                             length += monospaceWidth;
                         else
-                            length += (float)Math.Ceiling(fontData.CharSetMapping[c].rect.Width + fontData.meanGlyphWidth * options.CharacterSpacing + fontData.GetKerningPairCorrection(i, node.Text, node));
-                        height = Math.Max(height, glyph.yOffset + glyph.rect.Height);
+                            length += (float)Math.Ceiling(fontData.CharSetMapping[c].Rect.Width + fontData.MeanGlyphWidth * options.CharacterSpacing + fontData.GetKerningPairCorrection(i, node.Text, node));
+                        height = Math.Max(height, glyph.YOffset + glyph.Rect.Height);
                     }
                 }
             }
@@ -203,8 +276,12 @@ namespace QuickFont
             return newFirst;
         }
 
-        public void Add(TextNode node){
-
+        /// <summary>
+        /// Adds a node to the head of the doubly linked list
+        /// </summary>
+        /// <param name="node">The node to add</param>
+        public void Add(TextNode node)
+        {
             //new node is head (and tail)
             if(Head == null){
                 Head = node;
@@ -214,9 +291,12 @@ namespace QuickFont
                 node.Previous = Tail;
                 Tail = node;
             }
-
         }
 
+        /// <summary>
+        /// Returns the string representation of this text node object
+        /// </summary>
+        /// <returns>The text representation</returns>
         public override string ToString()
         {
             StringBuilder builder = new StringBuilder();
@@ -236,48 +316,55 @@ namespace QuickFont
 
             return builder.ToString();
         }
-        
-        #region IEnumerable Members
 
+        /// <summary>Returns an enumerator that iterates through a collection.</summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        /// <filterpriority>2</filterpriority>
         public IEnumerator GetEnumerator()
         {
             return new TextNodeListEnumerator(this);
         }
 
-        #endregion
-
-        private class TextNodeListEnumerator : IEnumerator
+        /// <summary>
+        /// An enumerator for the text node list
+        /// </summary>
+        private sealed class TextNodeListEnumerator : IEnumerator
         {
-            private TextNode currentNode = null;
-            private TextNodeList targetList;
+            private TextNode _currentNode;
+            private TextNodeList _targetList;
 
             public TextNodeListEnumerator(TextNodeList targetList)
             {
-                this.targetList = targetList;
+                _targetList = targetList;
             }
 
+            /// <summary>Gets the current element in the collection.</summary>
+            /// <returns>The current element in the collection.</returns>
+            /// <filterpriority>2</filterpriority>
             public object Current
             {
-                get { return currentNode; }
+                get { return _currentNode; }
             }
 
-            public virtual bool MoveNext()
+            /// <summary>Advances the enumerator to the next element of the collection.</summary>
+            /// <returns>true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.</returns>
+            /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception>
+            /// <filterpriority>2</filterpriority>
+            public bool MoveNext()
             {
-                if (currentNode == null)
-                    currentNode = targetList.Head;
+                if (_currentNode == null)
+                    _currentNode = _targetList.Head;
                 else
-                    currentNode = currentNode.Next;
-                return currentNode != null;
+                    _currentNode = _currentNode.Next;
+                return _currentNode != null;
             }
 
+            /// <summary>Sets the enumerator to its initial position, which is before the first element in the collection.</summary>
+            /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception>
+            /// <filterpriority>2</filterpriority>
             public void Reset()
             {
-                currentNode = null;
-            }
-
-            public void Dispose()
-            {
-
+                _currentNode = null;
             }
         }
     }

--- a/QuickFont.Shared/TexturePage.cs
+++ b/QuickFont.Shared/TexturePage.cs
@@ -11,39 +11,66 @@ using OpenTK.Graphics.OpenGL4;
 
 namespace QuickFont
 {
+    /// <summary>
+    /// Represents a texture page
+    /// </summary>
     class TexturePage : IDisposable
     {
-        int gLTexID;
-        int width;
-        int height;
+        private int _textureID;
 
-        public int GLTexID { get { return gLTexID; } }
-        public int Width { get { return width; } }
-        public int Height { get { return height; } }
+        /// <summary>
+        /// The texture ID of this texture page
+        /// </summary>
+        public int TextureID
+        {
+            get { return _textureID; }
+        }
 
+        /// <summary>
+        /// The width of this texture page
+        /// </summary>
+        public int Width { get; private set; }
+
+        /// <summary>
+        /// The height of this textur page
+        /// </summary>
+        public int Height { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TexturePage"/>
+        /// </summary>
+        /// <param name="filePath">The filepath to load as a bitmap</param>
         public TexturePage(string filePath)
         {
             var bitmap = new QBitmap(filePath);
-            CreateTexture(bitmap.bitmapData);
+            CreateTexture(bitmap.BitmapData);
             bitmap.Free();
         }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="TexturePage"/>
+        /// </summary>
+        /// <param name="dataSource">The bitmap to use as a data source</param>
         public TexturePage(BitmapData dataSource)
         {
             CreateTexture(dataSource);
         }
 
+        /// <summary>
+        /// Creates an OpenGL texture
+        /// </summary>
+        /// <param name="dataSource">The data source to use for the texture</param>
         private void CreateTexture(BitmapData dataSource)
         {
-            width = dataSource.Width;
-            height = dataSource.Height;
+            Width = dataSource.Width;
+            Height = dataSource.Height;
 
             Helper.SafeGLEnable(EnableCap.Texture2D, () =>
             {
                 GL.Hint(HintTarget.PerspectiveCorrectionHint, HintMode.Nicest);
 
-                GL.GenTextures(1, out gLTexID);
-                GL.BindTexture(TextureTarget.Texture2D, gLTexID);
+                GL.GenTextures(1, out _textureID);
+                GL.BindTexture(TextureTarget.Texture2D, TextureID);
 
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)TextureWrapMode.ClampToBorder);
                 GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)TextureWrapMode.ClampToBorder);
@@ -53,12 +80,12 @@ namespace QuickFont
 
 #if OPENGL_ES
                 var rawData = ConvertBgraToRgba(dataSource);
-                GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.Rgba, width, height, 0,
+                GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.Rgba, Width, Height, 0,
                     PixelFormat.Rgba, PixelType.UnsignedByte, rawData);
 
                 GL.GenerateMipmap(TextureTarget.Texture2D);
 #else
-                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, width, height, 0,
+                GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, Width, Height, 0,
                     OpenTK.Graphics.OpenGL4.PixelFormat.Bgra, PixelType.UnsignedByte, dataSource.Scan0);
 
                 GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
@@ -66,6 +93,11 @@ namespace QuickFont
             });
         }
 
+        /// <summary>
+        /// Converts a BGRA bitmap to RGBA
+        /// </summary>
+        /// <param name="dataSource">The bitmap to convert</param>
+        /// <returns>The converted bitmap bytes</returns>
         private static byte[] ConvertBgraToRgba(BitmapData dataSource)
         {
             var length = dataSource.Stride*dataSource.Height;
@@ -84,9 +116,12 @@ namespace QuickFont
             return rawData;
         }
 
+        /// <summary>
+        /// Dispose resources owned by this instance
+        /// </summary>
         public void Dispose()
         {
-            GL.DeleteTexture(gLTexID);
+            GL.DeleteTexture(TextureID);
         }
     }
 }

--- a/QuickFont.Shared/ViewportHelper.cs
+++ b/QuickFont.Shared/ViewportHelper.cs
@@ -36,7 +36,6 @@ namespace QuickFont
             GraphicsContext.Assert();
             int[] viewportInts = new int[4];
 
-            //TODO Test that this function returns the expected values -> tested, 96% sure it works.
             GL.GetInteger(GetPName.Viewport, viewportInts);
             _currentViewport = new Viewport(viewportInts[0], viewportInts[1], viewportInts[2], viewportInts[3]);
         }

--- a/QuickFont.Shared/ViewportHelper.cs
+++ b/QuickFont.Shared/ViewportHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using OpenTK;
+﻿using OpenTK;
 using OpenTK.Graphics;
 #if OPENGL_ES
 using OpenTK.Graphics.ES20;
@@ -9,15 +8,49 @@ using OpenTK.Graphics.OpenGL4;
 
 namespace QuickFont
 {
+    /// <summary>
+    /// Structure representing a viewport
+    /// </summary>
     public struct Viewport
     {
-        public float X, Y, Width, Height;
-        public Viewport(float X, float Y, float Width, float Height) { this.X = X; this.Y = Y; this.Width = Width; this.Height = Height; }
+        /// <summary>
+        /// The x coordinate of the viewport
+        /// </summary>
+        public float X;
+
+        /// <summary>
+        /// The y coordinate of the viewport
+        /// </summary>
+        public float Y;
+
+        /// <summary>
+        /// The width of the viewport
+        /// </summary>
+        public float Width;
+
+        /// <summary>
+        /// The height of the viewport
+        /// </summary>
+        public float Height;
+
+        /// <summary>
+        /// Creates a new <see cref="Viewport"/>
+        /// </summary>
+        /// <param name="x">The x coordinate of the viewport</param>
+        /// <param name="y">The y coordinate of the viewport</param>
+        /// <param name="width">The width of the viewport</param>
+        /// <param name="height">The height of the viewport</param>
+        public Viewport(float x, float y, float width, float height) { X = x; Y = y; Width = width; Height = height; }
     }
 
+    /// <summary>
+    /// Helper methods for dealing with the viewport
+    /// </summary>
     public static class ViewportHelper
     {
-        //The currently set viewport
+        /// <summary>
+        /// The current viewport
+        /// </summary>
         public static Viewport? CurrentViewport {
             get {
 
@@ -31,6 +64,9 @@ namespace QuickFont
         }
         private static Viewport? _currentViewport;
 
+        /// <summary>
+        /// Update the current viewport
+        /// </summary>
         public static void UpdateCurrentViewport()
         {
             GraphicsContext.Assert();
@@ -40,27 +76,24 @@ namespace QuickFont
             _currentViewport = new Viewport(viewportInts[0], viewportInts[1], viewportInts[2], viewportInts[3]);
         }
 
+
+        /// <summary>
+        /// Invalidate the stored viewpoint.
+        /// Will be refreshed the next time it is requested
+        /// </summary>
         public static void InvalidateViewport()
         {
             _currentViewport = null;
         }
 
+        /// <summary>
+        /// Returns true if the projection matrix is orthographic
+        /// </summary>
+        /// <param name="mat">The projection matrix to test</param>
+        /// <returns>True if the projection matrix is orthographic</returns>
         public static bool IsOrthographicProjection(ref Matrix4 mat)
         {
             return !(mat.M12 != 0 || mat.M13 != 0 || mat.M14 != 0 || mat.M21 != 0 || mat.M23 != 0 || mat.M24 != 0 || mat.M31 != 0 || mat.M32 != 0 || mat.M34 != 0 || mat.M44 != 1f);
-        }
-
-        public static Viewport GetViewportFromOrthographicProjection(ref Matrix4 mat)
-        {
-            if (!IsOrthographicProjection(ref mat)) throw new ArgumentException("Matrix is not an orthographic projection matrix", "mat");
-
-            float left = -(1f + mat.M41) / (mat.M11);
-            float right = (1f - mat.M41) / (mat.M11);
-
-            float bottom = -(1 + mat.M42) / (mat.M22);
-            float top = (1 - mat.M42) / (mat.M22);
-
-            return new Viewport(left, bottom, right-left, top-bottom);
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,2 @@
+before_build:
+  nuget restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,10 @@
+version: 4.3.{build}-appveyor
+image: Visual Studio 2015
+configuration:
+- Debug
+- Release
 before_build:
-  nuget restore
+- cmd: nuget restore
+build:
+  parallel: true
+  verbosity: minimal


### PR DESCRIPTION
* Kerning information is now loaded from FreeType if `FreeTypeFont` is used
* Improved built in kerning method to account for pixels on glyph boundary
* Fixes to example project
* Improved overall code quality
    * Renamed variables to a consistent naming scheme
    * Added XML documentation to all public facing classes, methods, fields, properties, etc.
    * Added lots of XML documentation to internal/private classes, methods, fields, properties etc
* Fixed `QFontDrawing` not implementing `IDisposable`
* Improved disposing in `QVertexArrayObject`